### PR TITLE
fix: Prevent role chaining to any role

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ No resources.
 | deployment_targets | Add a filter, and list of Organizational Units from the Organization to only deploy to. If left blank, all organization will be crawled by default. | `set(any)` | `[]` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | s3_kms_key_arn | Optional - ARN of the KMS Key that is used to encrypt CUR data | `string` | `null` | no |
+| prefix | Optional - prefix for key constructs created by this module. | `string` | `"cxm"` | no |
 | role_suffix | Optional - suffix to append to roles names. | `string` | `null` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
 

--- a/locals.tf
+++ b/locals.tf
@@ -5,6 +5,7 @@ locals {
   enable_benchmarking_account   = var.enable_benchmarking == true
   enable_cur                    = true
   enable_cloudtrail             = !var.disable_cloudtrail_analysis
+  prefix                        = var.prefix
   role_suffix                   = var.role_suffix != null ? "-${var.role_suffix}" : ""
   tags = merge({
     "provider" : "cxm",

--- a/main.tf
+++ b/main.tf
@@ -9,9 +9,11 @@ module "enable_root_organization" {
     aws = aws.root
   }
 
-  cxm_aws_account_id      = var.cxm_aws_account_id
-  cxm_external_id         = var.cxm_external_id
-  iam_role_name           = "cxm-organization-crawler${local.role_suffix}"
+  cxm_aws_account_id = var.cxm_aws_account_id
+  cxm_external_id    = var.cxm_external_id
+  prefix             = local.prefix
+  # This role name will be prefixed by local.prefix when deployed
+  iam_role_name           = "organization-crawler${local.role_suffix}"
   permission_boundary_arn = var.permission_boundary_arn
   tags                    = local.tags
 }
@@ -25,6 +27,7 @@ module "enable_sub_accounts" {
     aws = aws.root
   }
 
+  prefix                = local.prefix
   cxm_aws_account_id    = var.cxm_aws_account_id
   cxm_external_id       = var.cxm_external_id
   deployment_targets    = var.deployment_targets
@@ -43,9 +46,11 @@ module "enable_lone_account" {
     aws = aws.root
   }
 
-  cxm_aws_account_id      = var.cxm_aws_account_id
-  cxm_external_id         = var.cxm_external_id
-  iam_role_name           = "cxm-organization-crawler${local.role_suffix}"
+  cxm_aws_account_id = var.cxm_aws_account_id
+  cxm_external_id    = var.cxm_external_id
+  prefix             = local.prefix
+  # This role name will be prefixed by local.prefix when deployed
+  iam_role_name           = "organization-crawler${local.role_suffix}"
   permission_boundary_arn = var.permission_boundary_arn
   tags                    = local.tags
 }
@@ -60,9 +65,11 @@ module "enable_benchmarking_account" {
     aws = aws.benchmarking
   }
 
-  cxm_aws_account_id      = var.cxm_aws_account_id
-  cxm_external_id         = var.cxm_external_id
-  iam_role_name           = "cxm-benchmark-runner${local.role_suffix}"
+  cxm_aws_account_id = var.cxm_aws_account_id
+  cxm_external_id    = var.cxm_external_id
+  prefix             = local.prefix
+  # This role name will be prefixed by local.prefix when deployed
+  iam_role_name           = "benchmark-runner${local.role_suffix}"
   permission_boundary_arn = var.permission_boundary_arn
   tags                    = local.tags
 }
@@ -77,8 +84,10 @@ module "enable_cur" {
     aws = aws.cur
   }
 
-  iam_role_external_id  = var.cxm_external_id
-  iam_role_name         = "cxm-cur-reader${local.role_suffix}"
+  iam_role_external_id = var.cxm_external_id
+  prefix               = local.prefix
+  # This role name will be prefixed by local.prefix when deployed
+  iam_role_name         = "cur-reader${local.role_suffix}"
   cxm_aws_account_id    = var.cxm_aws_account_id
   s3_bucket_name        = var.cost_usage_report_bucket_name
   s3_bucket_kms_key_arn = var.s3_kms_key_arn
@@ -95,8 +104,10 @@ module "enable_cloudtrail" {
     aws = aws.cloudtrail
   }
 
-  iam_role_external_id  = var.cxm_external_id
-  iam_role_name         = "cxm-cloudtrail-reader${local.role_suffix}"
+  iam_role_external_id = var.cxm_external_id
+  prefix               = local.prefix
+  # This role name will be prefixed by local.prefix when deployed
+  iam_role_name         = "cloudtrail-reader${local.role_suffix}"
   cxm_aws_account_id    = var.cxm_aws_account_id
   s3_bucket_name        = var.cloudtrail_bucket_name
   s3_bucket_kms_key_arn = var.s3_kms_key_arn

--- a/terraform-aws-account-enablement/README.md
+++ b/terraform-aws-account-enablement/README.md
@@ -46,7 +46,8 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 |------|-------------|------|---------|:--------:|
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access. | `string` | n/a | yes |
 | cxm_external_id | External ID to use in the trust relationship. Required to match the existing External ID when setting use_existing_iam_role to `true`. | `string` | n/a | yes |
-| iam_role_name | Name of the IAM role to set. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. | `string` | n/a | yes |
+| iam_role_name | Name of the IAM role to set. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. Will be prefixed with var.prefix. | `string` | n/a | yes |
+| prefix | Prefix to use to name import constructs such as IAM roles when they are not set otherwise | `string` | `"cxm"` | no |
 | use_existing_iam_role | Set to true in order to use a pre-existing IAM role. Set iam_role_arn if you do. | `bool` | `false` | no |
 | use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role, rather than attaching a new one. | `bool` | `false` | no |
 | iam_role_arn | IAM role ARN to use. Required when setting use_existing_iam_role to `true`. | `string` | `null` | no |

--- a/terraform-aws-account-enablement/main.tf
+++ b/terraform-aws-account-enablement/main.tf
@@ -1,9 +1,9 @@
 locals {
   iam_role_arn         = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.arn : var.iam_role_arn
-  iam_role_name        = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.name : var.iam_role_name
+  iam_role_name        = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.name : "${var.prefix}-${var.iam_role_name}"
   iam_role_external_id = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.external_id : var.cxm_external_id
   cxm_read_only_policy_name = (
-    var.cxm_read_only_policy_name != null ? var.cxm_read_only_policy_name : "cxm-account-ro-${random_id.uniq.hex}"
+    var.cxm_read_only_policy_name != null ? var.cxm_read_only_policy_name : "${var.prefix}-account-ro-${random_id.uniq.hex}"
   )
 }
 
@@ -14,7 +14,7 @@ resource "random_id" "uniq" {
 module "cxm_cfg_iam_role" {
   source                  = "../terraform-aws-iam-role"
   dry_run                 = var.use_existing_iam_role ? true : false
-  iam_role_name           = var.iam_role_name
+  iam_role_name           = "${var.prefix}-${var.iam_role_name}"
   permission_boundary_arn = var.permission_boundary_arn
   cxm_aws_account_id      = var.cxm_aws_account_id
   external_id             = var.use_existing_iam_role ? "" : var.cxm_external_id

--- a/terraform-aws-account-enablement/variables.tf
+++ b/terraform-aws-account-enablement/variables.tf
@@ -12,11 +12,16 @@ variable "cxm_external_id" {
 
 variable "iam_role_name" {
   type        = string
-  description = "Name of the IAM role to set. Required to match with iam_role_arn if use_existing_iam_role is set to `true`."
+  description = "Name of the IAM role to set. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. Will be prefixed with var.prefix."
 }
 
-
 # Optional
+variable "prefix" {
+  type        = string
+  default     = "cxm"
+  description = "Prefix to use to name import constructs such as IAM roles when they are not set otherwise"
+}
+
 variable "use_existing_iam_role" {
   type        = bool
   default     = false

--- a/terraform-aws-benchmarking-account-enablement/README.md
+++ b/terraform-aws-benchmarking-account-enablement/README.md
@@ -48,6 +48,7 @@ Lambda Benchmarking requires permissions to duplicate existing lambda versions a
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access. | `string` | n/a | yes |
 | cxm_external_id | External ID to use in the trust relationship. Required to match the existing External ID when setting use_existing_iam_role to `true`. | `string` | n/a | yes |
 | iam_role_name | Name of the IAM role to set. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. | `string` | n/a | yes |
+| prefix | Prefix to use to name import constructs such as IAM roles when they are not set otherwise | `string` | `"cxm"` | no |
 | use_existing_iam_role | Set to true in order to use a pre-existing IAM role. Set iam_role_arn if you do. | `bool` | `false` | no |
 | use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role, rather than attaching a new one. | `bool` | `false` | no |
 | iam_role_arn | IAM role ARN to use. Required when setting use_existing_iam_role to `true`. | `string` | `null` | no |

--- a/terraform-aws-benchmarking-account-enablement/main.tf
+++ b/terraform-aws-benchmarking-account-enablement/main.tf
@@ -1,9 +1,9 @@
 locals {
   iam_role_arn         = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.arn : var.iam_role_arn
-  iam_role_name        = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.name : var.iam_role_name
+  iam_role_name        = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.name : "${var.prefix}-${var.iam_role_name}"
   iam_role_external_id = module.cxm_cfg_iam_role.created ? module.cxm_cfg_iam_role.external_id : var.cxm_external_id
   cxm_benchmarking_policy_name = (
-    var.cxm_benchmarking_policy_name != null ? var.cxm_benchmarking_policy_name : "cxm-benchmarking-${random_id.uniq.hex}"
+    var.cxm_benchmarking_policy_name != null ? var.cxm_benchmarking_policy_name : "${var.prefix}-benchmarking-${random_id.uniq.hex}"
   )
 }
 
@@ -14,7 +14,7 @@ resource "random_id" "uniq" {
 module "cxm_cfg_iam_role" {
   source                  = "../terraform-aws-iam-role"
   dry_run                 = var.use_existing_iam_role ? true : false
-  iam_role_name           = var.iam_role_name
+  iam_role_name           = "${var.prefix}-${var.iam_role_name}"
   permission_boundary_arn = var.permission_boundary_arn
   cxm_aws_account_id      = var.cxm_aws_account_id
   external_id             = var.use_existing_iam_role ? "" : var.cxm_external_id

--- a/terraform-aws-benchmarking-account-enablement/variables.tf
+++ b/terraform-aws-benchmarking-account-enablement/variables.tf
@@ -17,6 +17,12 @@ variable "iam_role_name" {
 
 
 # Optional
+variable "prefix" {
+  type        = string
+  default     = "cxm"
+  description = "Prefix to use to name import constructs such as IAM roles when they are not set otherwise"
+}
+
 variable "use_existing_iam_role" {
   type        = bool
   default     = false

--- a/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
+++ b/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
@@ -45,7 +45,7 @@ Resources:
             Action: sts:AssumeRole
             Condition:
               StringEquals:
-                sts:ExternalId: !Sub 'cxm:${CXMExternalID}'
+                sts:ExternalId: !Sub '${CXMExternalID}'
           - Effect: Allow
             Action:
               - sts:AssumeRole

--- a/terraform-aws-full-organization-enablement/main.tf
+++ b/terraform-aws-full-organization-enablement/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_cloudformation_stack_set" "cxm_account_enablement" {
-  name = "cxm-account-enablement${local.stack_and_role_suffix}"
+  name = "${var.prefix}-account-enablement${local.stack_and_role_suffix}"
   auto_deployment {
     enabled                          = true
     retain_stacks_on_account_removal = false

--- a/terraform-aws-iam-role/README.md
+++ b/terraform-aws-iam-role/README.md
@@ -42,6 +42,7 @@ No modules.
 | dry_run | Setting dry_run to `true` will prevent the module from creating new resources. | `bool` | `false` | no |
 | iam_role_name | The IAM role name | `string` | `null` | no |
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access. | `string` | `"596683793973"` | no |
+| prefix | Prefix to use for most resources created by this module. | `string` | `"cxm"` | no |
 | cxm_role_name | Name of the IAM role in the Cloud ex Machina AWS account that will assume this execution role | `string` | `null` | no |
 | external_id | External ID provided by Cloud ex Machina to configure the role. | `string` | `null` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |

--- a/terraform-aws-iam-role/main.tf
+++ b/terraform-aws-iam-role/main.tf
@@ -1,6 +1,6 @@
 locals {
-  iam_role_name = var.iam_role_name != null ? var.iam_role_name : "cxm-iam-role-${random_id.uniq.hex}"
-  external_id   = var.external_id != null ? "cxm:${var.external_id}" : "cxm:${random_id.uniq.hex}"
+  iam_role_name = var.iam_role_name != null ? var.iam_role_name : "${var.prefix}-iam-role-${random_id.uniq.hex}"
+  external_id   = var.external_id != null ? var.external_id : "cxm:${random_id.uniq.hex}"
   principal     = var.cxm_role_name != null ? "arn:aws:iam::${var.cxm_aws_account_id}:role/${var.cxm_role_name}" : "arn:aws:iam::${var.cxm_aws_account_id}:root"
 }
 

--- a/terraform-aws-iam-role/variables.tf
+++ b/terraform-aws-iam-role/variables.tf
@@ -17,6 +17,12 @@ variable "cxm_aws_account_id" {
   description = "The Cloud ex Machina AWS account that the IAM role will grant access."
 }
 
+variable "prefix" {
+  type        = string
+  default     = "cxm"
+  description = "Prefix to use for most resources created by this module."
+}
+
 variable "cxm_role_name" {
   type        = string
   default     = null

--- a/terraform-aws-organization-enablement/README.md
+++ b/terraform-aws-organization-enablement/README.md
@@ -60,7 +60,8 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 | cxm_external_id | External ID to use in the trust relationship. Provided by CXM. | `string` | n/a | yes |
 | use_existing_iam_role | Set this to some IAM role arn to force usage of an existing IAM role (default null) | `string` | `null` | no |
 | use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role. | `bool` | `false` | no |
-| iam_role_name | The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. | `string` | `"cxm-organization-crawler"` | no |
+| prefix | Prefix to use to name import constructs such as IAM roles when they are not set otherwise | `string` | `"cxm"` | no |
+| iam_role_name | The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. Note tht this name will be prefixed when left empty | `string` | `"organization-crawler"` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | cxm_read_only_policy_name | The name of the policy used to authorize Cloud ex Machina to read the AWS Organizations API.  Defaults to cxm-organizations-ro-${random_id.uniq.hex} when empty. | `string` | `null` | no |
 | tags | A map of K:V pairs to use as tags on all resources. | `map(string)` | `{}` | no |

--- a/terraform-aws-organization-enablement/variables.tf
+++ b/terraform-aws-organization-enablement/variables.tf
@@ -23,10 +23,16 @@ variable "use_existing_iam_role_policy" {
   description = "Set this to `true` to use an existing policy on the IAM role."
 }
 
+variable "prefix" {
+  type        = string
+  default     = "cxm"
+  description = "Prefix to use to name import constructs such as IAM roles when they are not set otherwise"
+}
+
 variable "iam_role_name" {
   type        = string
-  default     = "cxm-organization-crawler"
-  description = "The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`."
+  default     = "organization-crawler"
+  description = "The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`. Note tht this name will be prefixed when left empty"
 }
 
 variable "permission_boundary_arn" {

--- a/terraform-aws-s3-bucket-read/README.md
+++ b/terraform-aws-s3-bucket-read/README.md
@@ -55,6 +55,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role, rather than attaching a new one | `bool` | `false` | no |
 | iam_role_arn | The IAM role ARN is required when setting use_existing_iam_role to `true` | `string` | `null` | no |
 | iam_role_external_id | The external ID configured inside the IAM role is required when setting use_existing_iam_role to `true` | `string` | `null` | no |
+| prefix | Prefix to use for most resources created by this module. | `string` | `"cxm"` | no |
 | iam_role_name | The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true` | `string` | `"cxm-bucket-reader"` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access | `string` | n/a | yes |

--- a/terraform-aws-s3-bucket-read/variables.tf
+++ b/terraform-aws-s3-bucket-read/variables.tf
@@ -23,6 +23,12 @@ variable "iam_role_external_id" {
   description = "The external ID configured inside the IAM role is required when setting use_existing_iam_role to `true`"
 }
 
+variable "prefix" {
+  type        = string
+  default     = "cxm"
+  description = "Prefix to use for most resources created by this module."
+}
+
 variable "iam_role_name" {
   type        = string
   default     = "cxm-bucket-reader"

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "s3_kms_key_arn" {
   description = "Optional - ARN of the KMS Key that is used to encrypt CUR data"
 }
 
+variable "prefix" {
+  type        = string
+  default     = "cxm"
+  description = "Optional - prefix for key constructs created by this module."
+}
+
 variable "role_suffix" {
   type        = string
   default     = null


### PR DESCRIPTION
* Add a prefix variable that defaults to "cxm" to all modules
* Use the prefix for all constructs that start with "cxm-" such as roles and policies
* Update the jump role to only assume roles which names start with the prefix

* Also change to the external ID to remove the addition of "cxm:" which is confusing. The external ID remains whatever is set at the beginning. 

