### PR TITLE
fix: widen AWS provider constraint to support v6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ provider "aws" {
 | Name | Version |
 |------|---------|
 | terraform | >= 1.5.0 |
-| aws | ~> 5.0 |
+| aws | >= 5.0 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| aws.root | ~> 5.0 |
-| aws.cur | ~> 5.0 |
-| aws.cloudtrail | ~> 5.0 |
+| aws.root | >= 5.0 |
+| aws.cur | >= 5.0 |
+| aws.cloudtrail | >= 5.0 |
 
 ### Modules
 

--- a/provider.tf
+++ b/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.0"
+      version               = ">= 5.0"
       configuration_aliases = [aws.root, aws.cur, aws.cloudtrail, aws.benchmarking]
     }
   }


### PR DESCRIPTION
## Summary
- Changed AWS provider constraint from `~> 5.0` to `>= 5.0` in root `provider.tf`
- Resolves version conflict for consumers using AWS provider v6.x (`~> 5.0` caps at `< 6.0`)
- Submodules already use `>= 3.74.0` which is compatible with v6

## Test plan
- [ ] Verify `terraform init` succeeds with AWS provider v6.x pinned
- [ ] Verify `terraform init` still works with AWS provider v5.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)