### PR TITLE
feat: add scheduling and scaling permissions for FinOps optimization

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -35,7 +35,7 @@ These can be added to any deployment above:
 | EKS cluster access | [Bonus: EKS](#bonus-eks-cluster-enablement) | Grant CXM read-only access to EKS clusters |
 | CloudTrail analysis | [Enabling CloudTrail](#enabling-cloudtrail-analysis-optional) | Let CXM analyze CloudTrail logs for deeper usage insights |
 | VPC Flow Logs analysis | [Enabling Flow Logs](#enabling-vpc-flow-logs-analysis-optional) | Let CXM analyze centralized VPC Flow Logs from S3 |
-| Additional variables | [Optional Configuration](#optional-configuration) | Prefix, suffix, permission boundaries, KMS keys |
+| Additional variables | [Optional Configuration](#optional-configuration) | Prefix, suffix, permission boundaries, KMS keys, scheduling |
 
 ---
 
@@ -649,6 +649,7 @@ These variables can be added to any scenario above:
 | `disable_flowlogs_analysis` | `true` | Disable VPC Flow Logs analysis (see [Enabling Flow Logs Analysis](#enabling-vpc-flow-logs-analysis-optional)) |
 | `flowlogs_bucket_name` | `null` | S3 bucket storing centralized VPC Flow Logs (required when Flow Logs analysis is enabled) |
 | `flowlogs_kms_key_arn` | `null` | KMS key ARN for encrypted Flow Logs data in S3 |
+| `enable_scheduling` | `false` | Enable scheduling and scaling permissions for FinOps cost optimization |
 ### Example with optional variables
 
 ```hcl
@@ -681,3 +682,5 @@ module "cxm_integration" {
   }
 }
 ```
+
+> **Note on `enable_scheduling`:** When set to `true`, the module creates an additional IAM policy granting stop/start/scale permissions for EC2, RDS, ECS, EKS, ASG, Lambda, ElastiCache, Redshift, and SageMaker. Disabled by default — set to `true` to enable FinOps scheduling capabilities.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -684,3 +684,53 @@ module "cxm_integration" {
 ```
 
 > **Note on `enable_scheduling`:** When set to `true`, the module creates an additional IAM policy granting stop/start/scale permissions for EC2, RDS, ECS, EKS, ASG, Lambda, ElastiCache, Redshift, and SageMaker. Disabled by default — set to `true` to enable FinOps scheduling capabilities.
+
+---
+
+## Upgrading
+
+### Upgrading to 1.0.0
+
+This version introduces **breaking changes**:
+
+**1. Benchmarking module removed**
+
+The `enable_benchmarking` variable and `aws.benchmarking` provider alias have been removed. If you were using benchmarking, follow this upgrade sequence:
+
+```hcl
+# Step 1: Disable benchmarking BEFORE upgrading (on your current version)
+enable_benchmarking = false
+```
+
+```bash
+# Step 2: Apply to destroy benchmarking resources cleanly
+terraform apply
+```
+
+```hcl
+# Step 3: Upgrade module version and remove the aws.benchmarking provider alias
+module "cxm_integration" {
+  source  = "cxmlabs/cxm-integration/aws"
+  version = "1.0.0"
+
+  providers = {
+    aws.root       = aws.root
+    aws.cur        = aws.cur
+    aws.cloudtrail = aws.cloudtrail
+    # aws.benchmarking removed — delete this line
+  }
+
+  # enable_benchmarking removed — delete this line
+}
+```
+
+```bash
+# Step 4: Apply
+terraform apply
+```
+
+> **Warning:** If you remove the `aws.benchmarking` provider alias before disabling benchmarking, existing benchmarking resources will become orphaned in your Terraform state and cannot be cleanly destroyed.
+
+**2. New `enable_scheduling` variable**
+
+A new opt-in variable `enable_scheduling` (default: `false`) is available. Set to `true` to grant CXM stop/start/scale permissions for FinOps cost optimization.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ provider "aws" {
 | disable_cloudtrail_analysis | Disable Cloudtrail analysis permissions. This is strongly discouraged and will limit a lot the services provided by CXM. Enable by default. | `bool` | `false` | no |
 | disable_flowlogs_analysis | Disable VPC Flow Logs analysis. Disabled by default (opt-in). Set to false to enable. | `bool` | `true` | no |
 | use_lone_account_instead_of_aws_organization | If your AWS account is not using AWS Organization and is considered a 'lone account', set this to true. This will enable CXM on a single account. False by default. | `bool` | `false` | no |
+| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default. | `bool` | `true` | no |
 | deployment_targets | Add a filter, and list of Organizational Units from the Organization to only deploy to. If left blank, all organization will be crawled by default. | `set(any)` | `[]` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | s3_kms_key_arn | Optional - ARN of the KMS Key that is used to encrypt CUR data | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ provider "aws" {
 | disable_cloudtrail_analysis | Disable Cloudtrail analysis permissions. This is strongly discouraged and will limit a lot the services provided by CXM. Enable by default. | `bool` | `false` | no |
 | disable_flowlogs_analysis | Disable VPC Flow Logs analysis. Disabled by default (opt-in). Set to false to enable. | `bool` | `true` | no |
 | use_lone_account_instead_of_aws_organization | If your AWS account is not using AWS Organization and is considered a 'lone account', set this to true. This will enable CXM on a single account. False by default. | `bool` | `false` | no |
-| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default. | `bool` | `true` | no |
+| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Disabled by default. | `bool` | `false` | no |
 | deployment_targets | Add a filter, and list of Organizational Units from the Organization to only deploy to. If left blank, all organization will be crawled by default. | `set(any)` | `[]` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | s3_kms_key_arn | Optional - ARN of the KMS Key that is used to encrypt CUR data | `string` | `null` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -2,6 +2,7 @@ locals {
   # feature flags
   enable_root_org_discovery     = var.disable_asset_discovery == false && var.use_lone_account_instead_of_aws_organization == false
   enable_lone_account_discovery = var.disable_asset_discovery == false && var.use_lone_account_instead_of_aws_organization == true
+  enable_scheduling             = var.enable_scheduling == true
   enable_cur                    = !var.disable_cur_analysis
   enable_cloudtrail             = !var.disable_cloudtrail_analysis
   enable_flowlogs               = !var.disable_flowlogs_analysis

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ module "enable_sub_accounts" {
   deployment_targets    = var.deployment_targets
   cxm_admin_role_arn    = module.enable_root_organization[0].iam_role_arn
   stack_and_role_suffix = var.role_suffix
+  enable_scheduling     = local.enable_scheduling
   #tags                 = var.tags
 }
 
@@ -52,6 +53,7 @@ module "enable_lone_account" {
   # This role name will be prefixed by local.prefix when deployed
   iam_role_name           = "organization-crawler${local.role_suffix}"
   permission_boundary_arn = var.permission_boundary_arn
+  enable_scheduling       = local.enable_scheduling
   tags                    = local.tags
 }
 

--- a/terraform-aws-account-enablement/README.md
+++ b/terraform-aws-account-enablement/README.md
@@ -58,7 +58,7 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 | iam_role_arn | IAM role ARN to use. Required when setting use_existing_iam_role to `true`. | `string` | `null` | no |
 | permission_boundary_arn | Optional - ARN of a policy that is used to contraint permissions boundary for the role. | `string` | `null` | no |
 | cxm_read_only_policy_name | The name of the policy used to enrich ReadOnly to allow Cloud ex Machina to read the Control Plane.  Defaults to cxm-account-ro-${random_id.uniq.hex} when empty. | `string` | `null` | no |
-| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default. | `bool` | `true` | no |
+| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Disabled by default. | `bool` | `false` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources. | `map(string)` | `{}` | no |
 
 ### Outputs

--- a/terraform-aws-account-enablement/README.md
+++ b/terraform-aws-account-enablement/README.md
@@ -35,12 +35,15 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 | Name | Type |
 |------|------|
 | [aws_iam_policy.cxm_read_only_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cxm_scheduling_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.crawler_manage_ri_quotas_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.crawler_manage_sp_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cxm_read_only_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cxm_scheduling_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_only_access_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_iam_policy_document.cxm_read_only_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cxm_scheduling_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ### Inputs
 
@@ -55,6 +58,7 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 | iam_role_arn | IAM role ARN to use. Required when setting use_existing_iam_role to `true`. | `string` | `null` | no |
 | permission_boundary_arn | Optional - ARN of a policy that is used to contraint permissions boundary for the role. | `string` | `null` | no |
 | cxm_read_only_policy_name | The name of the policy used to enrich ReadOnly to allow Cloud ex Machina to read the Control Plane.  Defaults to cxm-account-ro-${random_id.uniq.hex} when empty. | `string` | `null` | no |
+| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default. | `bool` | `true` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources. | `map(string)` | `{}` | no |
 
 ### Outputs

--- a/terraform-aws-account-enablement/main.tf
+++ b/terraform-aws-account-enablement/main.tf
@@ -99,6 +99,101 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
     resources = ["*"]
   }
 
+  # ---------------------------------------------------------------------------
+  # Scaling & stop/start permissions (FinOps cost optimization)
+  # ---------------------------------------------------------------------------
+
+  statement {
+    sid = "ECSScaling"
+    actions = [
+      "ecs:UpdateService",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EC2StopStart"
+    actions = [
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "RDSStopStart"
+    actions = [
+      "rds:StartDBInstance",
+      "rds:StopDBInstance",
+      "rds:StartDBCluster",
+      "rds:StopDBCluster",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "LambdaConcurrency"
+    actions = [
+      "lambda:PutProvisionedConcurrencyConfig",
+      "lambda:DeleteProvisionedConcurrencyConfig",
+      "lambda:PutFunctionConcurrency",
+      "lambda:DeleteFunctionConcurrency",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EKSNodegroupScaling"
+    actions = [
+      "eks:UpdateNodegroupConfig",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ASGScaling"
+    actions = [
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AppAutoScaling"
+    actions = [
+      "application-autoscaling:RegisterScalableTarget",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ElastiCacheScaling"
+    actions = [
+      "elasticache:ModifyReplicationGroup",
+      "elasticache:ModifyCacheCluster",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "RedshiftScaling"
+    actions = [
+      "redshift:PauseCluster",
+      "redshift:ResumeCluster",
+      "redshift:ResizeCluster",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SageMakerScaling"
+    actions = [
+      "sagemaker:UpdateEndpointWeightsAndCapacities",
+    ]
+    resources = ["*"]
+  }
+
   statement {
     # Explicitly removing read access to S3 objects
     sid           = "ExplicitDenyOnS3Files"

--- a/terraform-aws-account-enablement/main.tf
+++ b/terraform-aws-account-enablement/main.tf
@@ -59,6 +59,7 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
       # EC2 Reservations
       "ec2:DescribeReserved*",
       "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeAccountAttributes",
       "ec2:DescribeRegions",
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceTypes",
@@ -153,8 +154,8 @@ resource "aws_iam_role_policy_attachment" "cxm_read_only_policy_attachment" {
 
 # ---------------------------------------------------------------------------
 # Scheduling & scaling permissions (FinOps cost optimization)
-# Controlled by var.enable_scheduling — opt-in for customers who want
-# CXM to stop/start/scale their workloads for cost savings.
+# Controlled by var.enable_scheduling (default: false). Set to true to grant
+# CXM permissions to stop/start/scale workloads for cost savings.
 # ---------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "cxm_scheduling_policy" {
@@ -218,6 +219,9 @@ data "aws_iam_policy_document" "cxm_scheduling_policy" {
   }
 
   statement {
+    # NOTE: RegisterScalableTarget covers all Application Auto Scaling namespaces
+    # (ECS, DynamoDB, AppStream, etc.), not just the services listed above.
+    # AWS does not offer namespace-scoped IAM actions for this service.
     sid = "AppAutoScaling"
     actions = [
       "application-autoscaling:RegisterScalableTarget",

--- a/terraform-aws-account-enablement/main.tf
+++ b/terraform-aws-account-enablement/main.tf
@@ -99,9 +99,67 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
     resources = ["*"]
   }
 
-  # ---------------------------------------------------------------------------
-  # Scaling & stop/start permissions (FinOps cost optimization)
-  # ---------------------------------------------------------------------------
+  statement {
+    # Explicitly removing read access to S3 objects
+    sid           = "ExplicitDenyOnS3Files"
+    effect        = "Deny"
+    actions       = ["s3:GetObject"]
+    not_resources = ["arn:aws:s3:::*/*"]
+  }
+
+  statement {
+    # Explicitly deny to any action that may allow to access customer data
+    sid    = "ExplicitDenyToDataPlane"
+    effect = "Deny"
+    actions = [
+      "athena:StartCalculationExecution",
+      "athena:StartQueryExecution",
+      "dynamodb:GetItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "ec2:GetConsoleOutput",
+      "ec2:GetConsoleScreenshot",
+      "ecr:BatchGetImage",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecs:RegisterTaskDefinition",
+      "kinesis:GetRecords",
+      "kinesis:GetShardIterator",
+      "lambda:GetFunction",
+      "logs:GetLogEvents",
+      "sdb:Select*",
+      "sqs:ReceiveMessage",
+      "rds-data:*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cxm_read_only_policy" {
+  count       = var.use_existing_iam_role_policy ? 0 : 1
+  name        = local.cxm_read_only_policy_name
+  description = "Policy enriching ReadOnly to allow Cloud ex Machina to read the Control Plane without accessing the Data Plane"
+  policy      = data.aws_iam_policy_document.cxm_read_only_policy[0].json
+  tags        = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cxm_read_only_policy_attachment" {
+  count      = var.use_existing_iam_role_policy ? 0 : 1
+  role       = local.iam_role_name
+  policy_arn = aws_iam_policy.cxm_read_only_policy[0].arn
+  depends_on = [module.cxm_cfg_iam_role]
+}
+
+# ---------------------------------------------------------------------------
+# Scheduling & scaling permissions (FinOps cost optimization)
+# Controlled by var.enable_scheduling — opt-in for customers who want
+# CXM to stop/start/scale their workloads for cost savings.
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "cxm_scheduling_policy" {
+  count   = var.use_existing_iam_role_policy || !var.enable_scheduling ? 0 : 1
+  version = "2012-10-17"
 
   statement {
     sid = "ECSScaling"
@@ -168,6 +226,9 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
   }
 
   statement {
+    # NOTE: These actions are broader than scaling alone (they also allow changing
+    # engine versions, parameter groups, etc.) but AWS does not offer more granular
+    # actions for ElastiCache scaling operations.
     sid = "ElastiCacheScaling"
     actions = [
       "elasticache:ModifyReplicationGroup",
@@ -177,6 +238,8 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
   }
 
   statement {
+    # NOTE: ResizeCluster also allows changing node types (not just counts),
+    # which could affect costs. PauseCluster/ResumeCluster are scheduling-only.
     sid = "RedshiftScaling"
     actions = [
       "redshift:PauseCluster",
@@ -193,54 +256,19 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
     ]
     resources = ["*"]
   }
-
-  statement {
-    # Explicitly removing read access to S3 objects
-    sid           = "ExplicitDenyOnS3Files"
-    effect        = "Deny"
-    actions       = ["s3:GetObject"]
-    not_resources = ["arn:aws:s3:::*/*"]
-  }
-
-  statement {
-    # Explicitly deny to any action that may allow to access customer data
-    sid    = "ExplicitDenyToDataPlane"
-    effect = "Deny"
-    actions = [
-      "athena:StartCalculationExecution",
-      "athena:StartQueryExecution",
-      "dynamodb:GetItem",
-      "dynamodb:BatchGetItem",
-      "dynamodb:Query",
-      "dynamodb:Scan",
-      "ec2:GetConsoleOutput",
-      "ec2:GetConsoleScreenshot",
-      "ecr:BatchGetImage",
-      "ecr:GetAuthorizationToken",
-      "ecr:GetDownloadUrlForLayer",
-      "kinesis:GetRecords",
-      "kinesis:GetShardIterator",
-      "lambda:GetFunction",
-      "logs:GetLogEvents",
-      "sdb:Select*",
-      "sqs:ReceiveMessage",
-      "rds-data:*"
-    ]
-    resources = ["*"]
-  }
 }
 
-resource "aws_iam_policy" "cxm_read_only_policy" {
-  count       = var.use_existing_iam_role_policy ? 0 : 1
-  name        = local.cxm_read_only_policy_name
-  description = "Policy enriching ReadOnly to allow Cloud ex Machina to read the Control Plane without accessing the Data Plane"
-  policy      = data.aws_iam_policy_document.cxm_read_only_policy[0].json
+resource "aws_iam_policy" "cxm_scheduling_policy" {
+  count       = var.use_existing_iam_role_policy || !var.enable_scheduling ? 0 : 1
+  name        = "${var.prefix}-scheduling-${random_id.uniq.hex}"
+  description = "Policy granting Cloud ex Machina scheduling and scaling permissions for FinOps cost optimization"
+  policy      = data.aws_iam_policy_document.cxm_scheduling_policy[0].json
   tags        = var.tags
 }
 
-resource "aws_iam_role_policy_attachment" "cxm_read_only_policy_attachment" {
-  count      = var.use_existing_iam_role_policy ? 0 : 1
+resource "aws_iam_role_policy_attachment" "cxm_scheduling_policy_attachment" {
+  count      = var.use_existing_iam_role_policy || !var.enable_scheduling ? 0 : 1
   role       = local.iam_role_name
-  policy_arn = aws_iam_policy.cxm_read_only_policy[0].arn
+  policy_arn = aws_iam_policy.cxm_scheduling_policy[0].arn
   depends_on = [module.cxm_cfg_iam_role]
 }

--- a/terraform-aws-account-enablement/variables.tf
+++ b/terraform-aws-account-enablement/variables.tf
@@ -55,8 +55,8 @@ variable "cxm_read_only_policy_name" {
 
 variable "enable_scheduling" {
   type        = bool
-  default     = true
-  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default."
+  default     = false
+  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Disabled by default."
 }
 
 variable "tags" {

--- a/terraform-aws-account-enablement/variables.tf
+++ b/terraform-aws-account-enablement/variables.tf
@@ -53,6 +53,12 @@ variable "cxm_read_only_policy_name" {
   description = "The name of the policy used to enrich ReadOnly to allow Cloud ex Machina to read the Control Plane.  Defaults to cxm-account-ro-$${random_id.uniq.hex} when empty."
 }
 
+variable "enable_scheduling" {
+  type        = bool
+  default     = true
+  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default."
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map/dictionary of Tags to be assigned to created resources."

--- a/terraform-aws-full-organization-enablement/README.md
+++ b/terraform-aws-full-organization-enablement/README.md
@@ -43,7 +43,7 @@ No modules.
 | deployment_targets | A list of Organizational Units from the Organization to deploy to. | `set(any)` | `[]` | no |
 | prefix | Prefix to use for all resources created by this module. | `string` | `"cxm"` | no |
 | stack_and_role_suffix | Suffix to use for the cloudformation stack. | `string` | `null` | no |
-| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default. | `bool` | `true` | no |
+| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Disabled by default. | `bool` | `false` | no |
 
 ### Outputs
 

--- a/terraform-aws-full-organization-enablement/README.md
+++ b/terraform-aws-full-organization-enablement/README.md
@@ -43,6 +43,7 @@ No modules.
 | deployment_targets | A list of Organizational Units from the Organization to deploy to. | `set(any)` | `[]` | no |
 | prefix | Prefix to use for all resources created by this module. | `string` | `"cxm"` | no |
 | stack_and_role_suffix | Suffix to use for the cloudformation stack. | `string` | `null` | no |
+| enable_scheduling | Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default. | `bool` | `true` | no |
 
 ### Outputs
 

--- a/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
+++ b/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
@@ -20,11 +20,11 @@ Parameters:
     Description: Role name suffix
   EnableScheduling:
     Type: String
-    Default: "true"
+    Default: "false"
     AllowedValues:
       - "true"
       - "false"
-    Description: Enable scheduling and scaling permissions for FinOps cost optimization
+    Description: Enable scheduling and scaling permissions for FinOps cost optimization (disabled by default)
 
 Conditions:
   SchedulingEnabled: !Equals [!Ref EnableScheduling, "true"]
@@ -188,7 +188,9 @@ Resources:
               # ASG Scaling
               - autoscaling:UpdateAutoScalingGroup
               - autoscaling:SetDesiredCapacity
-              # Application Auto Scaling
+              # Application Auto Scaling (NOTE: covers all App Auto Scaling
+              # namespaces — ECS, DynamoDB, AppStream, etc. — AWS does not
+              # offer namespace-scoped IAM actions for this service)
               - application-autoscaling:RegisterScalableTarget
               # ElastiCache Scaling (NOTE: these actions are broader than scaling
               # alone — they also allow changing engine versions, parameter groups,

--- a/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
+++ b/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
@@ -112,6 +112,42 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
+          # Scaling & stop/start permissions (FinOps cost optimization)
+          - Effect: Allow
+            Sid: SchedulingPermissions
+            Resource: "*"
+            Action:
+              # ECS Scaling
+              - ecs:UpdateService
+              # EC2 Stop/Start
+              - ec2:StartInstances
+              - ec2:StopInstances
+              # RDS Stop/Start
+              - rds:StartDBInstance
+              - rds:StopDBInstance
+              - rds:StartDBCluster
+              - rds:StopDBCluster
+              # Lambda Concurrency
+              - lambda:PutProvisionedConcurrencyConfig
+              - lambda:DeleteProvisionedConcurrencyConfig
+              - lambda:PutFunctionConcurrency
+              - lambda:DeleteFunctionConcurrency
+              # EKS Nodegroup Scaling
+              - eks:UpdateNodegroupConfig
+              # ASG Scaling
+              - autoscaling:UpdateAutoScalingGroup
+              - autoscaling:SetDesiredCapacity
+              # Application Auto Scaling
+              - application-autoscaling:RegisterScalableTarget
+              # ElastiCache Scaling
+              - elasticache:ModifyReplicationGroup
+              - elasticache:ModifyCacheCluster
+              # Redshift Scaling
+              - redshift:PauseCluster
+              - redshift:ResumeCluster
+              - redshift:ResizeCluster
+              # SageMaker Scaling
+              - sagemaker:UpdateEndpointWeightsAndCapacities
           # Explicitly denying data plane API Calls
           - Effect: Deny
             Resource: "*"

--- a/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
+++ b/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
@@ -18,6 +18,16 @@ Parameters:
     Type: String
     Default: ""
     Description: Role name suffix
+  EnableScheduling:
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable scheduling and scaling permissions for FinOps cost optimization
+
+Conditions:
+  SchedulingEnabled: !Equals [!Ref EnableScheduling, "true"]
 
 Resources:
   ################################################################
@@ -112,9 +122,50 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
-          # Scaling & stop/start permissions (FinOps cost optimization)
-          - Effect: Allow
-            Sid: SchedulingPermissions
+          # Explicitly denying data plane API Calls
+          - Sid: ExplicitDenyToDataPlane
+            Effect: Deny
+            Resource: "*"
+            Action:
+              - athena:StartCalculationExecution
+              - athena:StartQueryExecution
+              - dynamodb:GetItem
+              - dynamodb:BatchGetItem
+              - dynamodb:Query
+              - dynamodb:Scan
+              - ec2:GetConsoleOutput
+              - ec2:GetConsoleScreenshot
+              - ecr:BatchGetImage
+              - ecr:GetAuthorizationToken
+              - ecr:GetDownloadUrlForLayer
+              - ecs:RegisterTaskDefinition
+              - kinesis:GetRecords
+              - kinesis:GetShardIterator
+              - lambda:GetFunction
+              - logs:GetLogEvents
+              - sdb:Select*
+              - sqs:ReceiveMessage
+              - rds-data:*
+
+  ################################################################
+  #
+  # Scheduling & Scaling (FinOps cost optimization)
+  # Only created when EnableScheduling is "true"
+  #
+  ################################################################
+  SchedulingPolicy:
+    Type: AWS::IAM::Policy
+    Condition: SchedulingEnabled
+    DependsOn: IAMCrossAccountExecutionRole
+    Properties:
+      PolicyName: !Sub '${Prefix}-asset-crawler-scheduling${RoleSuffix}'
+      Roles:
+        - !Ref 'IAMCrossAccountExecutionRole'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: SchedulingPermissions
+            Effect: Allow
             Resource: "*"
             Action:
               # ECS Scaling
@@ -139,37 +190,19 @@ Resources:
               - autoscaling:SetDesiredCapacity
               # Application Auto Scaling
               - application-autoscaling:RegisterScalableTarget
-              # ElastiCache Scaling
+              # ElastiCache Scaling (NOTE: these actions are broader than scaling
+              # alone — they also allow changing engine versions, parameter groups,
+              # etc. — but AWS does not offer finer-grained actions)
               - elasticache:ModifyReplicationGroup
               - elasticache:ModifyCacheCluster
-              # Redshift Scaling
+              # Redshift Scaling (NOTE: ResizeCluster also allows changing node
+              # types, not just counts, which could affect costs)
               - redshift:PauseCluster
               - redshift:ResumeCluster
               - redshift:ResizeCluster
               # SageMaker Scaling
               - sagemaker:UpdateEndpointWeightsAndCapacities
-          # Explicitly denying data plane API Calls
-          - Effect: Deny
-            Resource: "*"
-            Action:
-              - athena:StartCalculationExecution
-              - athena:StartQueryExecution
-              - dynamodb:GetItem
-              - dynamodb:BatchGetItem
-              - dynamodb:Query
-              - dynamodb:Scan
-              - ec2:GetConsoleOutput
-              - ec2:GetConsoleScreenshot
-              - ecr:BatchGetImage
-              - ecr:GetAuthorizationToken
-              - ecr:GetDownloadUrlForLayer
-              - kinesis:GetRecords
-              - kinesis:GetShardIterator
-              - lambda:GetFunction
-              - logs:GetLogEvents
-              - sdb:Select*
-              - sqs:ReceiveMessage
-              - rds-data:*
+
   ################################################################
   #
   # Notifications for Feedback Loop

--- a/terraform-aws-full-organization-enablement/main.tf
+++ b/terraform-aws-full-organization-enablement/main.tf
@@ -17,6 +17,7 @@ resource "aws_cloudformation_stack_set" "cxm_account_enablement" {
     CustomerAccountID = var.cxm_aws_account_id
     AdminRoleArn      = var.cxm_admin_role_arn
     RoleSuffix        = local.stack_and_role_suffix
+    EnableScheduling  = var.enable_scheduling ? "true" : "false"
   }
 
   template_body = file("${path.module}/cxm-aws-account-enablement.yaml")

--- a/terraform-aws-full-organization-enablement/variables.tf
+++ b/terraform-aws-full-organization-enablement/variables.tf
@@ -32,3 +32,9 @@ variable "stack_and_role_suffix" {
   default     = null
   description = "Suffix to use for the cloudformation stack."
 }
+
+variable "enable_scheduling" {
+  type        = bool
+  default     = true
+  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default."
+}

--- a/terraform-aws-full-organization-enablement/variables.tf
+++ b/terraform-aws-full-organization-enablement/variables.tf
@@ -35,6 +35,6 @@ variable "stack_and_role_suffix" {
 
 variable "enable_scheduling" {
   type        = bool
-  default     = true
-  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default."
+  default     = false
+  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Disabled by default."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "use_lone_account_instead_of_aws_organization" {
   description = "If your AWS account is not using AWS Organization and is considered a 'lone account', set this to true. This will enable CXM on a single account. False by default."
 }
 
+variable "enable_scheduling" {
+  type        = bool
+  default     = true
+  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default."
+}
+
 ## Optional
 variable "deployment_targets" {
   type        = set(any)

--- a/variables.tf
+++ b/variables.tf
@@ -56,8 +56,8 @@ variable "use_lone_account_instead_of_aws_organization" {
 
 variable "enable_scheduling" {
   type        = bool
-  default     = true
-  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Enabled by default."
+  default     = false
+  description = "Enable scheduling and scaling permissions for FinOps cost optimization (stop/start EC2, RDS, scale ECS, ASG, etc.). Disabled by default."
 }
 
 ## Optional


### PR DESCRIPTION
## Summary
- Adds scheduling and scaling IAM permissions to the asset crawler role, enabling FinOps cost optimization actions in customer environments
- Permissions ported from the internal daneel-readonly module and cover: ECS, EC2, RDS, Lambda, EKS, ASG, Application Auto Scaling, ElastiCache, Redshift, and SageMaker
- Applied to both the Terraform account-enablement module and the StackSet CloudFormation template

## Test plan
- [ ] Run `terraform plan` against a test account to verify no unexpected changes beyond the new policy statements
- [ ] Validate the CloudFormation template with `aws cloudformation validate-template`
- [ ] Deploy to a sandbox account and verify the IAM policy contains all new actions
- [ ] Confirm data-plane deny statements still take precedence