### PR TITLE
fix(org-enablement): eliminate stackset drift and spurious taints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     -   id: trailing-whitespace
     -   id: check-added-large-files
     -   id: detect-aws-credentials
+        args: [--allow-missing-credentials]
     -   id: detect-private-key
     -   id: end-of-file-fixer
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
+++ b/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
@@ -189,12 +189,12 @@ Resources:
               - autoscaling:UpdateAutoScalingGroup
               - autoscaling:SetDesiredCapacity
               # Application Auto Scaling (NOTE: covers all App Auto Scaling
-              # namespaces — ECS, DynamoDB, AppStream, etc. — AWS does not
+              # namespaces (ECS, DynamoDB, AppStream, etc.); AWS does not
               # offer namespace-scoped IAM actions for this service)
               - application-autoscaling:RegisterScalableTarget
               # ElastiCache Scaling (NOTE: these actions are broader than scaling
-              # alone — they also allow changing engine versions, parameter groups,
-              # etc. — but AWS does not offer finer-grained actions)
+              # alone; they also allow changing engine versions, parameter groups,
+              # etc., but AWS does not offer finer-grained actions)
               - elasticache:ModifyReplicationGroup
               - elasticache:ModifyCacheCluster
               # Redshift Scaling (NOTE: ResizeCluster also allows changing node

--- a/terraform-aws-full-organization-enablement/main.tf
+++ b/terraform-aws-full-organization-enablement/main.tf
@@ -40,4 +40,15 @@ resource "aws_cloudformation_stack_set_instance" "cxm_account_enablement" {
     max_concurrent_count    = 10
     region_concurrency_type = "PARALLEL"
   }
+
+  # Default provider timeouts (30m) are too tight for orgs with many accounts:
+  # StackSet deployment runs in waves of max_concurrent_count, and each
+  # CloudFormation stack takes a few minutes per account. Hitting the timeout
+  # taints the resource and forces a full recreation on next apply even though
+  # the underlying StackSet is healthy.
+  timeouts {
+    create = "90m"
+    update = "90m"
+    delete = "90m"
+  }
 }


### PR DESCRIPTION
## Summary

Two small fixes to `terraform-aws-full-organization-enablement` that together remove two recurring sources of pain on every `terraform apply`, plus a pre-commit hook fix.

### 1. Permanent stackset template drift (ASCII-only comments)

The CloudFormation template at `cxm-aws-account-enablement.yaml` contained three em-dashes (`—`, U+2014) inside comments in the `SchedulingPolicy` section. Somewhere in the round-trip (CloudFormation's template storage, the botocore JSON decoder, or Terraform's diff library) those bytes get normalized to `?`, causing Terraform to see a permanent in-place update on every plan.

Fix: replace the em-dashes with plain ASCII punctuation. Semantics unchanged.

### 2. Stackset-instance taint after long applies

The default create/update timeout on `aws_cloudformation_stack_set_instance` is 30 minutes. With large AWS Organizations (10+ accounts) and `max_concurrent_count = 10`, a full deployment runs in serial waves of 10 accounts, each taking a few minutes per stack. Crossing the 30m default mid-deployment times out the Terraform resource and marks it tainted, which forces a full `destroy + replace` on the next apply — even though the underlying CloudFormation StackSet is healthy.

Fix: add a `timeouts` block with 90m for create/update/delete.

### 3. Allow missing AWS creds in detect-aws-credentials hook

Pre-commit `detect-aws-credentials` hook exited with code 2 in environments that do not have a local AWS credentials file (CI, fresh dev machines). Added `--allow-missing-credentials` so it scans the diff without requiring a creds file on disk.

## Behavior change

None functional. Consumers re-applying after pulling this:
- Will see **one** template-body update on the stackset (replacing the mangled \`?\` with plain ASCII in CloudFormation's stored template), then clean plans forever.
- Will no longer get spurious taints on large-org deployments.

## Test plan

- [x] Local `terraform apply` from a consumer repo (production-enablement) confirmed the em-dash drift is gone.
- [ ] After merge, verify a consumer apply finishes without hitting the 30m timeout on a ~16-account org.
- [ ] Confirm no \`terraform plan\` drift after a subsequent apply.