### PR TITLE
feat(s3-bucket-read): add s3:GetBucketLocation permission

### DIFF
--- a/terraform-aws-s3-bucket-read/main.tf
+++ b/terraform-aws-s3-bucket-read/main.tf
@@ -30,8 +30,8 @@ data "aws_iam_policy_document" "cxm_s3_ro_policy" {
   version = "2012-10-17"
 
   statement {
-    sid       = "ListFilesInBUcket"
-    actions   = ["s3:ListBucket"]
+    sid       = "ListFilesInBucket"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
     resources = ["arn:aws:s3:::${var.s3_bucket_name}"]
   }
 


### PR DESCRIPTION
## Summary
- Add `s3:GetBucketLocation` to the existing S3 read policy in `s3-bucket-read`
- Fix typo in SID (`ListFilesInBUcket` → `ListFilesInBucket`)

## Why
Preparing for Athena integration to query CUR data directly instead of pulling it to our database. Athena needs `s3:GetBucketLocation` to determine bucket region.

## Test plan
- [ ] `terraform plan` — expect policy update on existing CUR/CloudTrail/FlowLogs reader roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)