### PR TITLE
chore(docs): remove version pins from examples

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -113,7 +113,7 @@ provider "aws" {
 ```hcl
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws.root
@@ -221,7 +221,7 @@ provider "aws" {
 ```hcl
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws
@@ -304,7 +304,7 @@ Update the `main.tf` from Section 1 to include `deployment_targets`:
 ```hcl
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws.root
@@ -384,7 +384,7 @@ The default value of `deployment_targets` is `[]` (empty), which means the Stack
 ```hcl
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws.root
@@ -665,7 +665,7 @@ These variables can be added to any scenario above:
 ```hcl
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws.root
@@ -753,7 +753,7 @@ In your root module configuration, set `disable_stackset_deployment = true` to p
 ```hcl
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "1.0.0"
+
 
   # ... your existing Section 1 configuration ...
 
@@ -794,7 +794,7 @@ provider "aws" {
 # Module blocks — one per sub-account
 module "cxm_sub_account_engineering" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.engineering }
 
@@ -810,7 +810,7 @@ module "cxm_sub_account_engineering" {
 
 module "cxm_sub_account_staging" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.staging }
 
@@ -826,7 +826,7 @@ module "cxm_sub_account_staging" {
 
 module "cxm_sub_account_production" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.production }
 
@@ -904,7 +904,7 @@ terraform apply
 # Step 3: Upgrade module version and remove the aws.benchmarking provider alias
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "1.0.0"
+
 
   providers = {
     aws.root       = aws.root

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage example to setup your account, when using AWS Organisation :
 ```hcl
 module "cxm-integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws.root-us-east-1
@@ -47,7 +47,7 @@ provider "aws" {
 
 module "cxm-integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   providers = {
     aws.root       = aws
@@ -93,7 +93,7 @@ provider "aws" {
 
 module "cxm_sub_account_engineering" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.engineering }
 
@@ -106,7 +106,7 @@ module "cxm_sub_account_engineering" {
 
 module "cxm_sub_account_production" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.production }
 

--- a/terraform-aws-eks-cluster-enablement/README.md
+++ b/terraform-aws-eks-cluster-enablement/README.md
@@ -27,7 +27,7 @@ This Terraform module enables Cloud ex Machina (CXM) access to AWS EKS clusters 
 # First, enable CXM on the account/organization
 module "cxm_integration" {
   source  = "cxmlabs/cxm-integration/aws"
-  version = "0.4.2"
+
 
   cxm_aws_account_id = "123456789012"
   cxm_external_id    = "your-external-id"

--- a/terraform-aws-sub-account-cxm-enablement/README.md
+++ b/terraform-aws-sub-account-cxm-enablement/README.md
@@ -92,7 +92,7 @@ provider "aws" {
 # Module blocks
 module "cxm_sub_account_engineering" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.engineering }
 
@@ -105,7 +105,7 @@ module "cxm_sub_account_engineering" {
 
 module "cxm_sub_account_staging" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.staging }
 
@@ -118,7 +118,7 @@ module "cxm_sub_account_staging" {
 
 module "cxm_sub_account_production" {
   source  = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
-  version = "1.0.0"
+
 
   providers = { aws = aws.production }
 
@@ -185,7 +185,7 @@ Use Terragrunt to loop over accounts with a provider generated per account:
 ```hcl
 # terragrunt.hcl (in each account directory)
 terraform {
-  source = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement?version=1.0.0"
+  source = "cxmlabs/cxm-integration/aws//terraform-aws-sub-account-cxm-enablement"
 }
 
 generate "provider" {


### PR DESCRIPTION
## Summary
- Remove all hardcoded `version = "X.Y.Z"` lines from documentation examples across README.md, GUIDE.md, sub-account module README, and EKS module README
- Users get the latest version by default from the Terraform registry — pinning a version in docs goes stale on every release

## Test plan
- [x] Verified zero `version =` lines remain in all markdown files
- [x] All code examples still syntactically valid HCL

🤖 Generated with [Claude Code](https://claude.com/claude-code)