### PR TITLE
fix(docs): replace relative links with absolute GitHub URLs

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -876,7 +876,7 @@ Verify in member account consoles:
 | Explicit deny policy | Blocks data-plane access (Athena queries, DynamoDB reads, EC2 console, etc.) |
 | Scheduling policy (optional) | Stop/start/scale permissions when `enable_scheduling = true` |
 
-> **Tip:** For OpenTofu or Terragrunt users, see the [sub-account module README](./terraform-aws-sub-account-cxm-enablement/README.md#tips-for-opentofu-and-terragrunt) for automation patterns that reduce boilerplate.
+> **Tip:** For OpenTofu or Terragrunt users, see the [sub-account module README](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-sub-account-cxm-enablement#tips-for-opentofu-and-terragrunt) for automation patterns that reduce boilerplate.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ module "cxm_sub_account_production" {
 
 You configure the provider with whatever auth method you prefer (assume_role, SSO profile, etc.) — the module doesn't manage authentication. Set `disable_stackset_deployment = true` on the root module to skip the CloudFormation StackSet when using this approach.
 
-See the [sub-account module documentation](./terraform-aws-sub-account-cxm-enablement/README.md) for the full two-roles explanation, variables, and OpenTofu/Terragrunt tips, or [Section 5 of the Guide](./GUIDE.md#section-5-terraform-native-sub-account-deployment) for step-by-step instructions.
+See the [sub-account module documentation](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-sub-account-cxm-enablement) for the full two-roles explanation, variables, and OpenTofu/Terragrunt tips, or [Section 5 of the Guide](https://github.com/cxmlabs/terraform-aws-cxm-integration/blob/main/GUIDE.md#section-5-terraform-native-sub-account-deployment) for step-by-step instructions.
 
-> **Note:** Standard Terraform cannot dynamically create providers, so you need one module block per account. For auto-deployment to new accounts, use CloudFormation StackSets (the default — see [Section 4 of the Guide](./GUIDE.md#section-4-full-organization-setup)).
+> **Note:** Standard Terraform cannot dynamically create providers, so you need one module block per account. For auto-deployment to new accounts, use CloudFormation StackSets (the default — see [Section 4 of the Guide](https://github.com/cxmlabs/terraform-aws-cxm-integration/blob/main/GUIDE.md#section-4-full-organization-setup)).
 
 ### EKS Cluster Enablement
 
@@ -138,7 +138,7 @@ module "cxm_eks_enablement" {
 }
 ```
 
-This module automatically detects whether your EKS cluster supports modern access entries or requires the legacy aws-auth ConfigMap approach. The `cxm_iam_role_arn` output automatically selects the appropriate IAM role based on your deployment type (lone account vs organization). For detailed usage instructions, examples, and configuration options, see the [EKS cluster enablement module documentation](./terraform-aws-eks-cluster-enablement/README.md).
+This module automatically detects whether your EKS cluster supports modern access entries or requires the legacy aws-auth ConfigMap approach. The `cxm_iam_role_arn` output automatically selects the appropriate IAM role based on your deployment type (lone account vs organization). For detailed usage instructions, examples, and configuration options, see the [EKS cluster enablement module documentation](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-eks-cluster-enablement).
 
 ### About providers
 

--- a/terraform-aws-eks-cluster-enablement/README.md
+++ b/terraform-aws-eks-cluster-enablement/README.md
@@ -201,10 +201,10 @@ The module requires the following permissions:
 ## Examples
 
 ### Basic Usage
-See the [basic example](./examples/basic) for simple single-account, single-cluster setup.
+See the [basic example](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-eks-cluster-enablement/examples/basic) for simple single-account, single-cluster setup.
 
 ### Advanced Organization-Wide Deployment
-See the [organization multi-cluster example](./examples/organization-multi-cluster) for enterprise-scale deployment across multiple AWS accounts and EKS clusters within an AWS Organization.
+See the [organization multi-cluster example](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-eks-cluster-enablement/examples/organization-multi-cluster) for enterprise-scale deployment across multiple AWS accounts and EKS clusters within an AWS Organization.
 
 **Advanced Example Features:**
 - Multi-account EKS cluster access (Production + Staging)

--- a/terraform-aws-sub-account-cxm-enablement/README.md
+++ b/terraform-aws-sub-account-cxm-enablement/README.md
@@ -6,8 +6,8 @@ Deploys CXM asset-crawler IAM roles and EventBridge feedback loop into a single 
 
 | Scenario | Recommended approach |
 |----------|---------------------|
-| Full org, auto-deploy to new accounts | Root module with StackSet ([Section 4](../GUIDE.md#section-4-full-organization-setup)) |
-| OU-scoped StackSet deployment | Root module with `deployment_targets` ([Section 3](../GUIDE.md#section-3-deploy-to-a-single-ou)) |
+| Full org, auto-deploy to new accounts | Root module with StackSet ([Section 4](https://github.com/cxmlabs/terraform-aws-cxm-integration/blob/main/GUIDE.md#section-4-full-organization-setup)) |
+| OU-scoped StackSet deployment | Root module with `deployment_targets` ([Section 3](https://github.com/cxmlabs/terraform-aws-cxm-integration/blob/main/GUIDE.md#section-3-deploy-to-a-single-ou)) |
 | Terraform-only (no CloudFormation) | **This module** — one block per account |
 | Selective accounts, full Terraform control | **This module** — one block per account |
 | Terragrunt multi-account automation | **This module** + Terragrunt (see [tips below](#terragrunt)) |
@@ -55,7 +55,7 @@ The provisioning role is only used during `terraform apply`. The runtime role is
 
 ## Prerequisites
 
-- [Section 1: Organization Foundation](../GUIDE.md#section-1-organization-foundation) deployed (provides the `organization_iam_role_arn` needed for `cxm_admin_role_arn`)
+- [Section 1: Organization Foundation](https://github.com/cxmlabs/terraform-aws-cxm-integration/blob/main/GUIDE.md#section-1-organization-foundation) deployed (provides the `organization_iam_role_arn` needed for `cxm_admin_role_arn`)
 - Terraform >= 1.5.0 and AWS provider >= 5.0
 - A provider configured to authenticate into each target sub-account
 


### PR DESCRIPTION
## Summary
- Replace 8 relative markdown links (`./`, `../`) with absolute GitHub URLs across README.md, GUIDE.md, sub-account module README, and EKS module README
- Relative links break on the Terraform Registry — absolute GitHub URLs work everywhere

## Test plan
- [x] Verified zero relative links remain in all markdown files
- [x] All links point to correct GitHub paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)