### PR TITLE
chore: add debug outputs to all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,4 +265,8 @@ provider "aws" {
 | flowlogs_iam_role_arn | ARN of the CXM IAM role for VPC Flow Logs reading |
 | stackset_deployment_region | AWS region where StackSet instances deploy IAM roles in member accounts (hardcoded to us-east-1) |
 | discovered_account_ids | Active sub-account IDs discovered from the organization. Use these to set up the terraform-aws-sub-account-cxm-enablement module. |
+| prefix | Prefix used for all resource names across modules. |
+| role_suffix | Suffix appended to IAM role names. |
+| organization_assume_role_target_pattern | IAM resource pattern the org-crawler is allowed to assume into member accounts. Sub-account roles must match this pattern. |
+| sub_account_expected_role_name | Expected IAM role name in sub-accounts. Pass this as the asset-crawler role name when running diagnostics. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,3 +73,23 @@ output "discovered_account_ids" {
   value       = local.enable_root_org_discovery ? [for acct in data.aws_organizations_organization.org[0].non_master_accounts : acct.id if acct.status == "ACTIVE"] : []
   description = "Active sub-account IDs discovered from the organization. Use these to set up the terraform-aws-sub-account-cxm-enablement module."
 }
+
+output "prefix" {
+  value       = local.prefix
+  description = "Prefix used for all resource names across modules."
+}
+
+output "role_suffix" {
+  value       = local.role_suffix
+  description = "Suffix appended to IAM role names."
+}
+
+output "organization_assume_role_target_pattern" {
+  value       = local.enable_root_org_discovery ? "arn:aws:iam::*:role/${local.prefix}-*" : null
+  description = "IAM resource pattern the org-crawler is allowed to assume into member accounts. Sub-account roles must match this pattern."
+}
+
+output "sub_account_expected_role_name" {
+  value       = "${local.prefix}-asset-crawler${local.role_suffix}"
+  description = "Expected IAM role name in sub-accounts. Pass this as the asset-crawler role name when running diagnostics."
+}

--- a/terraform-aws-account-enablement/README.md
+++ b/terraform-aws-account-enablement/README.md
@@ -68,4 +68,6 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 | external_id | The External ID configured into the IAM role |
 | iam_role_name | The IAM Role name |
 | iam_role_arn | The IAM Role ARN |
+| prefix | Prefix used for all resource names. |
+| cxm_aws_account_id | CXM AWS account ID trusted by the IAM role. |
 <!-- END_TF_DOCS -->

--- a/terraform-aws-account-enablement/outputs.tf
+++ b/terraform-aws-account-enablement/outputs.tf
@@ -12,3 +12,13 @@ output "iam_role_arn" {
   value       = local.iam_role_arn
   description = "The IAM Role ARN"
 }
+
+output "prefix" {
+  value       = var.prefix
+  description = "Prefix used for all resource names."
+}
+
+output "cxm_aws_account_id" {
+  value       = var.cxm_aws_account_id
+  description = "CXM AWS account ID trusted by the IAM role."
+}

--- a/terraform-aws-full-organization-enablement/README.md
+++ b/terraform-aws-full-organization-enablement/README.md
@@ -53,4 +53,7 @@ No modules.
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access. |
 | prefix | Prefix to use for all resources created by this module. |
 | iam_role_name | CxM IAM Role deployed in all accounts |
+| trusted_admin_role_arn | ARN of the org-crawler role trusted to assume into sub-account asset-crawler roles. |
+| stack_and_role_suffix | Suffix appended to StackSet and IAM role names. |
+| stackset_name | Name of the CloudFormation StackSet deploying roles to member accounts. |
 <!-- END_TF_DOCS -->

--- a/terraform-aws-full-organization-enablement/outputs.tf
+++ b/terraform-aws-full-organization-enablement/outputs.tf
@@ -17,3 +17,18 @@ output "iam_role_name" {
   value       = "${var.prefix}-asset-crawler${local.stack_and_role_suffix}"
   description = "CxM IAM Role deployed in all accounts"
 }
+
+output "trusted_admin_role_arn" {
+  value       = var.cxm_admin_role_arn
+  description = "ARN of the org-crawler role trusted to assume into sub-account asset-crawler roles."
+}
+
+output "stack_and_role_suffix" {
+  value       = local.stack_and_role_suffix
+  description = "Suffix appended to StackSet and IAM role names."
+}
+
+output "stackset_name" {
+  value       = aws_cloudformation_stack_set.cxm_account_enablement.name
+  description = "Name of the CloudFormation StackSet deploying roles to member accounts."
+}

--- a/terraform-aws-organization-enablement/README.md
+++ b/terraform-aws-organization-enablement/README.md
@@ -76,4 +76,7 @@ It also forbids CXM to access any customer data other than cloud usage & metrics
 | external_id | The External ID configured into the IAM role. |
 | iam_role_name | The IAM Role name. |
 | iam_role_arn | The IAM Role ARN. |
+| prefix | Prefix used for all resource names. |
+| cxm_aws_account_id | CXM AWS account ID trusted by the IAM role. |
+| assume_role_target_pattern | IAM resource pattern the org-crawler is allowed to assume into member accounts. |
 <!-- END_TF_DOCS -->

--- a/terraform-aws-organization-enablement/outputs.tf
+++ b/terraform-aws-organization-enablement/outputs.tf
@@ -12,3 +12,18 @@ output "iam_role_arn" {
   value       = local.iam_role_arn
   description = "The IAM Role ARN."
 }
+
+output "prefix" {
+  value       = var.prefix
+  description = "Prefix used for all resource names."
+}
+
+output "cxm_aws_account_id" {
+  value       = var.cxm_aws_account_id
+  description = "CXM AWS account ID trusted by the IAM role."
+}
+
+output "assume_role_target_pattern" {
+  value       = "arn:aws:iam::*:role/${var.prefix}-*"
+  description = "IAM resource pattern the org-crawler is allowed to assume into member accounts."
+}

--- a/terraform-aws-s3-bucket-read/README.md
+++ b/terraform-aws-s3-bucket-read/README.md
@@ -73,4 +73,6 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | iam_role_name | The IAM Role name |
 | iam_role_arn | The IAM Role ARN |
 | s3_bucket_name | Name of the S3 Bucket |
+| prefix | Prefix used for all resource names. |
+| cxm_aws_account_id | CXM AWS account ID trusted by the IAM role. |
 <!-- END_TF_DOCS -->

--- a/terraform-aws-s3-bucket-read/outputs.tf
+++ b/terraform-aws-s3-bucket-read/outputs.tf
@@ -17,3 +17,13 @@ output "s3_bucket_name" {
   value       = var.s3_bucket_name
   description = "Name of the S3 Bucket"
 }
+
+output "prefix" {
+  value       = var.prefix
+  description = "Prefix used for all resource names."
+}
+
+output "cxm_aws_account_id" {
+  value       = var.cxm_aws_account_id
+  description = "CXM AWS account ID trusted by the IAM role."
+}

--- a/terraform-aws-sub-account-cxm-enablement/README.md
+++ b/terraform-aws-sub-account-cxm-enablement/README.md
@@ -133,27 +133,15 @@ module "cxm_sub_account_production" {
 
 # Outputs — useful for debugging connectivity issues with CXM support
 output "cxm_sub_account_engineering" {
-  value = {
-    iam_role_arn           = module.cxm_sub_account_engineering.iam_role_arn
-    trusted_admin_role_arn = module.cxm_sub_account_engineering.trusted_admin_role_arn
-    prefix                 = module.cxm_sub_account_engineering.prefix
-  }
+  value = module.cxm_sub_account_engineering
 }
 
 output "cxm_sub_account_staging" {
-  value = {
-    iam_role_arn           = module.cxm_sub_account_engineering.iam_role_arn
-    trusted_admin_role_arn = module.cxm_sub_account_staging.trusted_admin_role_arn
-    prefix                 = module.cxm_sub_account_staging.prefix
-  }
+  value = module.cxm_sub_account_staging
 }
 
 output "cxm_sub_account_production" {
-  value = {
-    iam_role_arn           = module.cxm_sub_account_production.iam_role_arn
-    trusted_admin_role_arn = module.cxm_sub_account_production.trusted_admin_role_arn
-    prefix                 = module.cxm_sub_account_production.prefix
-  }
+  value = module.cxm_sub_account_production
 }
 ```
 

--- a/terraform-aws-sub-account-cxm-enablement/README.md
+++ b/terraform-aws-sub-account-cxm-enablement/README.md
@@ -130,6 +130,31 @@ module "cxm_sub_account_production" {
 
   tags = { "ManagedBy" = "terraform" }
 }
+
+# Outputs — useful for debugging connectivity issues with CXM support
+output "cxm_sub_account_engineering" {
+  value = {
+    iam_role_arn           = module.cxm_sub_account_engineering.iam_role_arn
+    trusted_admin_role_arn = module.cxm_sub_account_engineering.trusted_admin_role_arn
+    prefix                 = module.cxm_sub_account_engineering.prefix
+  }
+}
+
+output "cxm_sub_account_staging" {
+  value = {
+    iam_role_arn           = module.cxm_sub_account_engineering.iam_role_arn
+    trusted_admin_role_arn = module.cxm_sub_account_staging.trusted_admin_role_arn
+    prefix                 = module.cxm_sub_account_staging.prefix
+  }
+}
+
+output "cxm_sub_account_production" {
+  value = {
+    iam_role_arn           = module.cxm_sub_account_production.iam_role_arn
+    trusted_admin_role_arn = module.cxm_sub_account_production.trusted_admin_role_arn
+    prefix                 = module.cxm_sub_account_production.prefix
+  }
+}
 ```
 
 ### Discovering account IDs
@@ -168,7 +193,19 @@ aws organizations list-accounts \
 |------|-------------|
 | `iam_role_arn` | ARN of the CXM asset-crawler IAM role |
 | `iam_role_name` | Name of the CXM asset-crawler IAM role |
+| `trusted_admin_role_arn` | ARN of the admin role trusted to assume into the asset-crawler |
+| `prefix` | Prefix used for all resource names |
+| `role_suffix` | Suffix appended to IAM role names |
+| `cxm_aws_account_id` | CXM AWS account ID used in trust and event forwarding policies |
 | `feedback_loop_role_arn` | ARN of the feedback loop IAM role for EventBridge forwarding |
+
+## Troubleshooting
+
+If the CXM platform cannot assume into a sub-account, run `terraform output` and share the result with CXM support. The key values to verify:
+
+- `trusted_admin_role_arn` must match the organization-crawler role ARN from the root module (`organization_iam_role_arn`)
+- `prefix` must match the prefix used in the root module deployment
+- `iam_role_name` must match the pattern the org-crawler is allowed to assume (`<prefix>-*`)
 
 ## Tips for OpenTofu and Terragrunt
 

--- a/terraform-aws-sub-account-cxm-enablement/outputs.tf
+++ b/terraform-aws-sub-account-cxm-enablement/outputs.tf
@@ -8,6 +8,26 @@ output "iam_role_name" {
   description = "Name of the CXM asset-crawler IAM role."
 }
 
+output "trusted_admin_role_arn" {
+  value       = var.cxm_admin_role_arn
+  description = "ARN of the admin role trusted to assume into this sub-account's asset-crawler role."
+}
+
+output "prefix" {
+  value       = var.prefix
+  description = "Prefix used for all resource names."
+}
+
+output "role_suffix" {
+  value       = var.role_suffix
+  description = "Suffix appended to IAM role names."
+}
+
+output "cxm_aws_account_id" {
+  value       = var.cxm_aws_account_id
+  description = "CXM AWS account ID used in trust and event forwarding policies."
+}
+
 output "feedback_loop_role_arn" {
   value       = aws_iam_role.feedback_loop.arn
   description = "ARN of the feedback loop IAM role for EventBridge forwarding."


### PR DESCRIPTION
## Summary

- Add debug outputs (prefix, trusted ARNs, CXM account ID, assume-role patterns) to all modules
- Customers can now share `terraform output` for fast IAM trust chain troubleshooting
- Updated sub-account README with outputs table, troubleshooting section, and example output blocks

## Modules updated

| Module | New outputs |
|--------|-------------|
| root | `prefix`, `role_suffix`, `organization_assume_role_target_pattern`, `sub_account_expected_role_name` |
| organization-enablement | `prefix`, `cxm_aws_account_id`, `assume_role_target_pattern` |
| full-organization-enablement | `trusted_admin_role_arn`, `stack_and_role_suffix`, `stackset_name` |
| sub-account-cxm-enablement | `trusted_admin_role_arn`, `prefix`, `role_suffix`, `cxm_aws_account_id` |
| account-enablement | `prefix`, `cxm_aws_account_id` |
| s3-bucket-read | `prefix`, `cxm_aws_account_id` |

## Motivation

Debugging cross-account IAM trust chain issues currently requires reading Terraform state or inspecting IAM policies in the AWS console. These outputs let customers run `terraform output` and share the result, giving us everything needed to pinpoint mismatches (wrong admin role ARN, prefix inconsistency, etc.).