### PR TITLE
fix: add explicit bedrock read permissions to asset-crawler role

### DIFF
--- a/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
+++ b/terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml
@@ -122,6 +122,12 @@ Resources:
               - memorydb:PurchaseReservedNodesOffering
               # Saving Plans full management
               - savingsplans:*
+          - Sid: BedrockInventoryPermissions
+            Effect: Allow
+            Resource: "*"
+            Action:
+              - bedrock:List*
+              - bedrock:Get*
           # Explicitly denying data plane API Calls
           - Sid: ExplicitDenyToDataPlane
             Effect: Deny

--- a/terraform-aws-sub-account-cxm-enablement/policies.tf
+++ b/terraform-aws-sub-account-cxm-enablement/policies.tf
@@ -63,6 +63,15 @@ resource "aws_iam_role_policy" "inventory" {
         ]
       },
       {
+        Sid      = "BedrockInventoryPermissions"
+        Effect   = "Allow"
+        Resource = "*"
+        Action = [
+          "bedrock:List*",
+          "bedrock:Get*",
+        ]
+      },
+      {
         Sid      = "ExplicitDenyToDataPlane"
         Effect   = "Deny"
         Resource = "*"


### PR DESCRIPTION
## Summary

- Add `bedrock:List*` + `bedrock:Get*` to the `InventoryPolicy` statement in both CloudFormation (`cxm-aws-account-enablement.yaml`) and Terraform (`policies.tf`) integration modules
- AWS managed `ReadOnlyAccess` v186 is missing `bedrock:ListImportedModels` and `bedrock:ListMarketplaceModelEndpoints`, causing `AccessDeniedException` in the inventory crawler

**Companion PR:** cxmlabs/koomo#5582 — makes the crawler resilient to `UnknownOperationException` and `InternalServerErrorException` (but intentionally does NOT swallow `AccessDeniedException`)

## Test plan

- [x] Pre-commit hooks pass (Terraform fmt, validate, docs)
- [ ] Deploy updated StackSet to cava and verify bedrock crawlers succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)