### PR TITLE
fix(sub-account): allow lambda:GetFunction for inventory crawler

### DIFF
--- a/terraform-aws-sub-account-cxm-enablement/policies.tf
+++ b/terraform-aws-sub-account-cxm-enablement/policies.tf
@@ -90,7 +90,6 @@ resource "aws_iam_role_policy" "inventory" {
           "ecs:RegisterTaskDefinition",
           "kinesis:GetRecords",
           "kinesis:GetShardIterator",
-          "lambda:GetFunction",
           "logs:GetLogEvents",
           "sdb:Select*",
           "sqs:ReceiveMessage",


### PR DESCRIPTION
## Why

The `aws_lambda_functions` inventory crawler calls both `lambda:ListFunctions` and `lambda:GetFunction`. `GetFunction` was in `ExplicitDenyToDataPlane`, producing ~352 AccessDenied errors in nightly Dagster after ListFunctions started working.

`GetFunction` returns function configuration (needed by inventory). It also returns a presigned code-download URL — the original deny reason — but the crawler only reads configuration and never fetches the code.

## Change

Remove `lambda:GetFunction` from `ExplicitDenyToDataPlane`.

Companion to the CloudFormation integration-template PR so CFN- and TF-enrolled accounts stay identical.