### PR TITLE
feat(s3-bucket-read): add a customer bucket resource-policy path for in-place log querying

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -641,6 +641,136 @@ No provider changes needed — `aws.flowlogs` already points to `aws` (same acco
 
 ---
 
+## Querying Logs In Place (Bucket and Key Resource Policies)
+
+CXM can analyse your CloudTrail and VPC Flow Logs **in place** — reading the objects
+straight out of your bucket instead of copying them into ours. Nothing leaves your account,
+and you pay no duplicate storage.
+
+This needs a grant the reader role above cannot provide. Athena reads S3 as the principal
+that submitted the query and cannot be handed an assumed-role session, so the cross-account
+role and its external ID never enter the read path. The bucket must therefore grant access
+in its **own** policy — a resource policy — and, when the objects are encrypted with a
+customer managed key, the key must do the same in its key policy.
+
+### Which mode to use
+
+| Your bucket | Mode | Why |
+|-------------|------|-----|
+| CloudTrail or VPC Flow Logs delivery bucket | **Merge the statements yourself** (default) | These buckets always carry AWS log-delivery statements (`cloudtrail.amazonaws.com`, `delivery.logs.amazonaws.com`). A Terraform-owned `aws_s3_bucket_policy` replaces the *whole* policy, which would silently stop your log delivery. |
+| Bucket dedicated to this integration, with no policy you rely on | `manage_bucket_policy = true` on the `terraform-aws-s3-bucket-read` submodule | Terraform reads the current policy and merges into it, so nothing pre-existing is dropped. |
+
+The default mode is the safe one and is what the root module uses: it creates **no** bucket
+or key policy resource, it only renders the statements you need.
+
+### Default mode: apply the rendered statements yourself
+
+After `terraform apply`, read the statements out of the outputs:
+
+```bash
+terraform output -json inplace_query_bucket_policy_statements
+terraform output -json inplace_query_kms_key_policy_statements
+```
+
+Each value is a complete policy document whose statements you paste into the bucket's
+existing policy (and, if the bucket is encrypted, into the key's existing policy). The
+bucket grant looks like this — `REPLACE_WITH_*` placeholders are filled in for you by the
+output:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CxMInPlaceGetObject",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::REPLACE_WITH_BUCKET_NAME/AWSLogs/*"
+    },
+    {
+      "Sid": "CxMInPlaceListBucket",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::REPLACE_WITH_BUCKET_NAME",
+      "Condition": { "StringLike": { "s3:prefix": "AWSLogs/*" } }
+    },
+    {
+      "Sid": "CxMInPlaceGetBucketLocation",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
+      "Action": "s3:GetBucketLocation",
+      "Resource": "arn:aws:s3:::REPLACE_WITH_BUCKET_NAME"
+    }
+  ]
+}
+```
+
+And the key grant:
+
+```json
+{
+  "Sid": "CxMInPlaceDecrypt",
+  "Effect": "Allow",
+  "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
+  "Action": ["kms:Decrypt", "kms:DescribeKey"],
+  "Resource": "*"
+}
+```
+
+Three points worth keeping when you adapt this:
+
+- **Keep the three statements separate.** `s3:GetBucketLocation` does not support the
+  `s3:prefix` condition key, so folding it in with `s3:ListBucket` makes AWS reject the
+  whole policy as `MalformedPolicy`. A rejected `put-bucket-policy` leaves the previous
+  policy in place, which looks like success — always read the policy back afterwards.
+- **Do not add an `aws:CalledVia` condition.** Athena does not populate `aws:CalledVia` on
+  its scan requests, so the condition denies the very queries you are enabling.
+- **The principal is the CXM account, not a role.** Access is narrowed by object prefix
+  instead. Our submitting roles are named per tenant and per service, so naming them would
+  break your policy every time one is renamed.
+
+### Opt-in mode: let Terraform own the policy
+
+Only for a bucket dedicated to this integration. Call the submodule directly:
+
+```hcl
+module "cxm_dedicated_bucket" {
+  source = "cxmlabs/cxm-integration/aws//terraform-aws-s3-bucket-read"
+
+  cxm_aws_account_id   = "REPLACE_WITH_CXM_ACCOUNT_ID"
+  iam_role_external_id = "REPLACE_WITH_CXM_EXTERNAL_ID"
+  s3_bucket_name       = "REPLACE_WITH_BUCKET_NAME"
+
+  manage_bucket_policy = true
+
+  # Set to false only for a bucket that has no policy at all.
+  # merge_existing_bucket_policy = true
+
+  # Encrypted bucket: hand in the key's current policy so it is merged, not replaced.
+  # s3_bucket_kms_key_arn        = "REPLACE_WITH_KMS_KEY_ARN"
+  # manage_kms_key_policy        = true
+  # existing_kms_key_policy_json = file("current-key-policy.json")
+}
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `manage_bucket_policy` | `false` | Let Terraform own the bucket policy. |
+| `merge_existing_bucket_policy` | `true` | Read the bucket's current policy and merge into it. Set to `false` only when the bucket has no policy — the read fails otherwise. |
+| `inplace_query_object_prefix` | `"AWSLogs"` | Object key prefix the grant is narrowed to. |
+| `manage_kms_key_policy` | `false` | Let Terraform own the key policy of `s3_bucket_kms_key_arn`. |
+| `existing_kms_key_policy_json` | `null` | The key's current policy. Required with `manage_kms_key_policy` — AWS exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable. |
+
+> **Drift warning.** If anything else also manages that bucket policy — another Terraform
+> configuration, a CloudFormation stack, a console edit — the two will fight: each apply
+> re-reads the current policy and merges into it, so an out-of-band statement survives, but
+> an out-of-band *removal* of a CXM statement is silently restored and vice versa. Keep a
+> single owner per bucket policy.
+
+---
+
 ## Optional Configuration
 
 These variables can be added to any scenario above:

--- a/README.md
+++ b/README.md
@@ -185,23 +185,23 @@ provider "aws" {
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.5.0 |
 | aws | >= 5.0 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
-| aws.root | >= 5.0 |
-| aws.cur | >= 5.0 |
-| aws.cloudtrail | >= 5.0 |
-| aws.flowlogs | >= 5.0 |
+| ---- | ------- |
+| aws.root | 6.58.0 |
+| aws.cur | 6.58.0 |
+| aws.cloudtrail | 6.58.0 |
+| aws.flowlogs | 6.58.0 |
 
 ### Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | enable_root_organization | ./terraform-aws-organization-enablement | n/a |
 | enable_sub_accounts | ./terraform-aws-full-organization-enablement | n/a |
 | enable_lone_account | ./terraform-aws-account-enablement | n/a |
@@ -212,7 +212,7 @@ provider "aws" {
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_caller_identity.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.cur](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.flowlogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -226,7 +226,7 @@ provider "aws" {
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access to. Provided by CXM. | `string` | n/a | yes |
 | cxm_external_id | External ID to use in the trust relationship. Provided by CXM. | `string` | n/a | yes |
 | cost_usage_report_bucket_name | Name of the bucket that is used to store CUR data. Required when disable_cur_analysis is false (the default). | `string` | `null` | no |
@@ -250,7 +250,7 @@ provider "aws" {
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | lone_account_iam_role_arn | ARN of the CXM IAM role for lone account deployment |
 | organization_iam_role_arn | ARN of the CXM IAM role for organization root deployment |
 | cxm_iam_role_name | Name of the CXM IAM role (automatically selects between lone account or organization deployment) |
@@ -263,6 +263,8 @@ provider "aws" {
 | flowlogs_account_id | AWS account ID where the VPC Flow Logs reader role is deployed |
 | flowlogs_region | AWS region used for the VPC Flow Logs deployment (must match the Flow Logs S3 bucket region) |
 | flowlogs_iam_role_arn | ARN of the CXM IAM role for VPC Flow Logs reading |
+| inplace_query_bucket_policy_statements | Bucket policy statements to merge into each log bucket's existing policy so CXM can query it in place, keyed by data source. |
+| inplace_query_kms_key_policy_statements | KMS key policy statements to merge into each log bucket's encryption key policy, keyed by data source. Empty when no customer managed key is configured. |
 | stackset_deployment_region | AWS region where StackSet instances deploy IAM roles in member accounts (hardcoded to us-east-1) |
 | discovered_account_ids | Active sub-account IDs discovered from the organization. Use these to set up the terraform-aws-sub-account-cxm-enablement module. |
 | prefix | Prefix used for all resource names across modules. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -64,6 +64,26 @@ output "flowlogs_iam_role_arn" {
   description = "ARN of the CXM IAM role for VPC Flow Logs reading"
 }
 
+# In-place query access. These buckets always carry AWS log-delivery statements, so the
+# module never owns their policies: it renders the statements to merge into your own.
+output "inplace_query_bucket_policy_statements" {
+  value = merge(
+    local.enable_cloudtrail ? { cloudtrail = module.enable_cloudtrail[0].inplace_query_bucket_policy_statements_json } : {},
+    local.enable_flowlogs ? { flowlogs = module.enable_flowlogs[0].inplace_query_bucket_policy_statements_json } : {},
+  )
+  description = "Bucket policy statements to merge into each log bucket's existing policy so CXM can query it in place, keyed by data source."
+}
+
+output "inplace_query_kms_key_policy_statements" {
+  value = {
+    for source, statement in merge(
+      local.enable_cloudtrail ? { cloudtrail = module.enable_cloudtrail[0].inplace_query_kms_key_policy_statement_json } : {},
+      local.enable_flowlogs ? { flowlogs = module.enable_flowlogs[0].inplace_query_kms_key_policy_statement_json } : {},
+    ) : source => statement if statement != null
+  }
+  description = "KMS key policy statements to merge into each log bucket's encryption key policy, keyed by data source. Empty when no customer managed key is configured."
+}
+
 output "stackset_deployment_region" {
   value       = local.enable_root_org_discovery ? "us-east-1" : null
   description = "AWS region where StackSet instances deploy IAM roles in member accounts (hardcoded to us-east-1)"

--- a/terraform-aws-s3-bucket-read/README.md
+++ b/terraform-aws-s3-bucket-read/README.md
@@ -11,7 +11,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.5.0 |
 | aws | >= 3.74.0 |
 | random | >= 2.1 |
@@ -19,20 +19,20 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 ### Providers
 
 | Name | Version |
-|------|---------|
-| random | >= 2.1 |
-| aws | >= 3.74.0 |
+| ---- | ------- |
+| random | 3.9.0 |
+| aws | 6.58.0 |
 
 ### Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | cxm_cfg_iam_role | ../terraform-aws-iam-role | n/a |
 
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.cxm_bucket_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.cxm_data_plane_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.cxm_cross_account_eventbridge_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -40,17 +40,24 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | [aws_iam_role.cxm_feedback_loop_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cxm_cross_account_eventbridge_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cxm_s3_ro_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_key_policy.cxm_inplace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_policy.cxm_inplace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_iam_policy_document.cxm_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cxm_cross_account_eventbridge_put_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cxm_inplace_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cxm_inplace_bucket_statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cxm_inplace_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cxm_inplace_kms_statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cxm_s3_ro_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_s3_bucket_policy.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_policy) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | use_existing_iam_role | Set this to true to use an existing IAM role | `bool` | `false` | no |
 | use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role, rather than attaching a new one | `bool` | `false` | no |
 | iam_role_arn | The IAM role ARN is required when setting use_existing_iam_role to `true` | `string` | `null` | no |
@@ -63,16 +70,24 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | s3_bucket_name | Name of the bucket that is used to store CUR data | `string` | n/a | yes |
 | s3_bucket_kms_key_arn | Optional - ARN of the KMS Key that is used to encrypt CUR data | `string` | `null` | no |
 | cxm_s3_read_policy_name | Name of the IAM Policy to read the bucket. Defaults to cxm-s3-ro-policy-${random_id.uniq.hex} when empty | `string` | `null` | no |
+| inplace_query_object_prefix | Object key prefix the in-place query grant is narrowed to. A trailing `/` is added automatically. | `string` | `"AWSLogs"` | no |
+| manage_bucket_policy | Set to `true` only for a bucket dedicated to this integration. Terraform then owns the bucket policy. Leave `false` for CloudTrail and VPC Flow Logs buckets: they carry AWS log-delivery statements, and taking ownership risks breaking log delivery. In the default mode the required statements are exposed as outputs for you to merge into your own policy. | `bool` | `false` | no |
+| merge_existing_bucket_policy | When manage_bucket_policy is `true`, read the bucket's current policy and merge into it instead of replacing it. Set to `false` only for a bucket that has no policy at all — the read fails otherwise. | `bool` | `true` | no |
+| manage_kms_key_policy | Set to `true` to let Terraform own the KMS key policy of s3_bucket_kms_key_arn. Requires existing_kms_key_policy_json. Leave `false` to take the statement from the outputs instead. | `bool` | `false` | no |
+| existing_kms_key_policy_json | Current policy of s3_bucket_kms_key_arn, merged with the CXM decrypt statement. Required when manage_kms_key_policy is `true`: the AWS provider exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable. | `string` | `null` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
 
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | external_id | The External ID configured into the IAM role |
 | iam_role_name | The IAM Role name |
 | iam_role_arn | The IAM Role ARN |
 | s3_bucket_name | Name of the S3 Bucket |
 | prefix | Prefix used for all resource names. |
 | cxm_aws_account_id | CXM AWS account ID trusted by the IAM role. |
+| inplace_query_bucket_policy_statements_json | Bucket policy statements granting CXM in-place query access. Merge these into the bucket's existing policy when manage_bucket_policy is `false`. |
+| inplace_query_kms_key_policy_statement_json | KMS key policy statement granting CXM decrypt access. Merge this into the key's existing policy when manage_kms_key_policy is `false`. Null when the bucket is not encrypted with a customer managed key. |
+| inplace_query_object_prefix | Object key prefix the in-place query grant is narrowed to. |
 <!-- END_TF_DOCS -->

--- a/terraform-aws-s3-bucket-read/inplace-query-access.tf
+++ b/terraform-aws-s3-bucket-read/inplace-query-access.tf
@@ -1,0 +1,132 @@
+# In-place query access (resource policy).
+#
+# Athena reads S3 as the principal that submitted the query and cannot be handed an
+# assumed-role session, so the identity policy in main.tf never applies to the scan path.
+# A resource policy on the bucket (and on the KMS key, when the bucket is encrypted) is
+# the only grant that works. The principal is account-delegated and narrowed by object
+# prefix, never by role name: submitting roles are named per tenant and per service, so
+# naming them would break the policy on any rename.
+
+locals {
+  inplace_object_prefix = "${trimsuffix(var.inplace_query_object_prefix, "/")}/"
+  inplace_bucket_arn    = "arn:aws:s3:::${var.s3_bucket_name}"
+  inplace_cxm_principal = "arn:aws:iam::${var.cxm_aws_account_id}:root"
+  inplace_kms_statement = var.s3_bucket_kms_key_arn != null || var.manage_kms_key_policy
+}
+
+# Three separate statements are mandatory: s3:GetBucketLocation does not support the
+# s3:prefix condition key, so folding it in with s3:ListBucket is rejected as
+# MalformedPolicy — and a rejected PutBucketPolicy leaves the previous policy live.
+# Do NOT add an aws:CalledVia condition here: Athena does not populate CalledVia on its
+# scan requests, so the condition denies Athena itself.
+data "aws_iam_policy_document" "cxm_inplace_bucket_statements" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "CxMInPlaceGetObject"
+    actions   = ["s3:GetObject"]
+    resources = ["${local.inplace_bucket_arn}/${local.inplace_object_prefix}*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [local.inplace_cxm_principal]
+    }
+  }
+
+  statement {
+    sid       = "CxMInPlaceListBucket"
+    actions   = ["s3:ListBucket"]
+    resources = [local.inplace_bucket_arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [local.inplace_cxm_principal]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["${local.inplace_object_prefix}*"]
+    }
+  }
+
+  statement {
+    sid       = "CxMInPlaceGetBucketLocation"
+    actions   = ["s3:GetBucketLocation"]
+    resources = [local.inplace_bucket_arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [local.inplace_cxm_principal]
+    }
+  }
+}
+
+# The identity-policy kms:Decrypt in main.tf does not substitute for a key policy: the
+# query submitter is not the role that identity policy is attached to.
+# kms:GenerateDataKey is write-side only and deliberately excluded.
+data "aws_iam_policy_document" "cxm_inplace_kms_statement" {
+  count   = local.inplace_kms_statement ? 1 : 0
+  version = "2012-10-17"
+
+  statement {
+    sid       = "CxMInPlaceDecrypt"
+    actions   = ["kms:Decrypt", "kms:DescribeKey"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [local.inplace_cxm_principal]
+    }
+  }
+}
+
+# Opt-in ownership of the bucket policy. Only ever safe on a bucket dedicated to this
+# integration: aws_s3_bucket_policy replaces the whole policy, and log buckets always
+# carry AWS log-delivery statements that must survive.
+data "aws_s3_bucket_policy" "existing" {
+  count  = var.manage_bucket_policy && var.merge_existing_bucket_policy ? 1 : 0
+  bucket = var.s3_bucket_name
+}
+
+data "aws_iam_policy_document" "cxm_inplace_bucket_policy" {
+  count   = var.manage_bucket_policy ? 1 : 0
+  version = "2012-10-17"
+
+  source_policy_documents = concat(
+    [for existing in data.aws_s3_bucket_policy.existing : existing.policy],
+    [data.aws_iam_policy_document.cxm_inplace_bucket_statements.json],
+  )
+}
+
+resource "aws_s3_bucket_policy" "cxm_inplace" {
+  count  = var.manage_bucket_policy ? 1 : 0
+  bucket = var.s3_bucket_name
+  policy = data.aws_iam_policy_document.cxm_inplace_bucket_policy[count.index].json
+}
+
+# The AWS provider exposes no data source for an existing KMS key policy, so the current
+# policy must be handed in explicitly. Replacing a key policy without its administrative
+# statements locks the key permanently, hence the precondition rather than a silent default.
+data "aws_iam_policy_document" "cxm_inplace_kms_key_policy" {
+  count   = var.manage_kms_key_policy ? 1 : 0
+  version = "2012-10-17"
+
+  source_policy_documents = [
+    var.existing_kms_key_policy_json,
+    data.aws_iam_policy_document.cxm_inplace_kms_statement[0].json,
+  ]
+}
+
+resource "aws_kms_key_policy" "cxm_inplace" {
+  count  = var.manage_kms_key_policy ? 1 : 0
+  key_id = var.s3_bucket_kms_key_arn
+  policy = data.aws_iam_policy_document.cxm_inplace_kms_key_policy[count.index].json
+
+  lifecycle {
+    precondition {
+      condition     = var.s3_bucket_kms_key_arn != null && var.existing_kms_key_policy_json != null
+      error_message = "manage_kms_key_policy requires both s3_bucket_kms_key_arn and existing_kms_key_policy_json: the current key policy must be merged in, or the key becomes unmanageable."
+    }
+  }
+}

--- a/terraform-aws-s3-bucket-read/outputs.tf
+++ b/terraform-aws-s3-bucket-read/outputs.tf
@@ -27,3 +27,18 @@ output "cxm_aws_account_id" {
   value       = var.cxm_aws_account_id
   description = "CXM AWS account ID trusted by the IAM role."
 }
+
+output "inplace_query_bucket_policy_statements_json" {
+  value       = data.aws_iam_policy_document.cxm_inplace_bucket_statements.json
+  description = "Bucket policy statements granting CXM in-place query access. Merge these into the bucket's existing policy when manage_bucket_policy is `false`."
+}
+
+output "inplace_query_kms_key_policy_statement_json" {
+  value       = one(data.aws_iam_policy_document.cxm_inplace_kms_statement[*].json)
+  description = "KMS key policy statement granting CXM decrypt access. Merge this into the key's existing policy when manage_kms_key_policy is `false`. Null when the bucket is not encrypted with a customer managed key."
+}
+
+output "inplace_query_object_prefix" {
+  value       = local.inplace_object_prefix
+  description = "Object key prefix the in-place query grant is narrowed to."
+}

--- a/terraform-aws-s3-bucket-read/tests/inplace_query_access.tftest.hcl
+++ b/terraform-aws-s3-bucket-read/tests/inplace_query_access.tftest.hcl
@@ -1,0 +1,109 @@
+# Guards the two failure modes that would hurt a customer: emitting a grant Athena cannot
+# use, and replacing a log bucket's policy instead of merging into it.
+
+provider "aws" {
+  region                      = "eu-west-1"
+  access_key                  = "mock"
+  secret_key                  = "mock"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+}
+
+variables {
+  cxm_aws_account_id    = "000000000000"
+  iam_role_external_id  = "example-external-id"
+  s3_bucket_name        = "example-log-bucket"
+  s3_bucket_kms_key_arn = "arn:aws:kms:eu-west-1:000000000000:key/00000000-0000-0000-0000-000000000000"
+}
+
+run "default_mode_emits_statements_without_owning_the_policy" {
+  command = plan
+
+  assert {
+    condition     = length(aws_s3_bucket_policy.cxm_inplace) == 0
+    error_message = "Default mode must not take ownership of the bucket policy."
+  }
+
+  assert {
+    condition     = length(aws_kms_key_policy.cxm_inplace) == 0
+    error_message = "Default mode must not take ownership of the KMS key policy."
+  }
+
+  assert {
+    condition = [
+      for statement in jsondecode(output.inplace_query_bucket_policy_statements_json).Statement : statement.Sid
+    ] == ["CxMInPlaceGetObject", "CxMInPlaceListBucket", "CxMInPlaceGetBucketLocation"]
+    error_message = "The grant must stay three separate statements: s3:GetBucketLocation rejects the s3:prefix condition."
+  }
+
+  assert {
+    condition = [
+      for statement in jsondecode(output.inplace_query_bucket_policy_statements_json).Statement :
+      statement.Condition.StringLike["s3:prefix"] if statement.Sid == "CxMInPlaceListBucket"
+    ] == ["AWSLogs/*"]
+    error_message = "s3:ListBucket must be narrowed by the s3:prefix condition."
+  }
+
+  assert {
+    condition = alltrue([
+      for statement in jsondecode(output.inplace_query_bucket_policy_statements_json).Statement :
+      statement.Principal.AWS == "arn:aws:iam::000000000000:root"
+    ])
+    error_message = "The principal must be the CXM account, not a named role."
+  }
+
+  assert {
+    condition     = !strcontains(output.inplace_query_bucket_policy_statements_json, "CalledVia")
+    error_message = "aws:CalledVia denies Athena: it does not populate that key on scan requests."
+  }
+
+  assert {
+    condition = jsondecode(output.inplace_query_kms_key_policy_statement_json).Statement[0].Action == [
+      "kms:DescribeKey", "kms:Decrypt"
+    ]
+    error_message = "The KMS statement must grant exactly decrypt and describe; GenerateDataKey is write-side only."
+  }
+}
+
+run "merge_mode_preserves_the_log_delivery_statement" {
+  command = plan
+
+  variables {
+    manage_bucket_policy = true
+  }
+
+  override_data {
+    target = data.aws_s3_bucket_policy.existing[0]
+    values = {
+      policy = <<-JSON
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AWSLogDeliveryWrite",
+              "Effect": "Allow",
+              "Principal": {"Service": "delivery.logs.amazonaws.com"},
+              "Action": "s3:PutObject",
+              "Resource": "arn:aws:s3:::example-log-bucket/AWSLogs/*"
+            }
+          ]
+        }
+      JSON
+    }
+  }
+
+  assert {
+    condition = contains([
+      for statement in jsondecode(aws_s3_bucket_policy.cxm_inplace[0].policy).Statement : statement.Sid
+    ], "AWSLogDeliveryWrite")
+    error_message = "Merge mode dropped the pre-existing log-delivery statement."
+  }
+
+  assert {
+    condition = length([
+      for statement in jsondecode(aws_s3_bucket_policy.cxm_inplace[0].policy).Statement : statement.Sid
+    ]) == 4
+    error_message = "Merge mode must add the three CXM statements to the existing one."
+  }
+}

--- a/terraform-aws-s3-bucket-read/variables.tf
+++ b/terraform-aws-s3-bucket-read/variables.tf
@@ -69,6 +69,36 @@ variable "cxm_s3_read_policy_name" {
   description = "Name of the IAM Policy to read the bucket. Defaults to cxm-s3-ro-policy-$${random_id.uniq.hex} when empty"
 }
 
+variable "inplace_query_object_prefix" {
+  type        = string
+  default     = "AWSLogs"
+  description = "Object key prefix the in-place query grant is narrowed to. A trailing `/` is added automatically."
+}
+
+variable "manage_bucket_policy" {
+  type        = bool
+  default     = false
+  description = "Set to `true` only for a bucket dedicated to this integration. Terraform then owns the bucket policy. Leave `false` for CloudTrail and VPC Flow Logs buckets: they carry AWS log-delivery statements, and taking ownership risks breaking log delivery. In the default mode the required statements are exposed as outputs for you to merge into your own policy."
+}
+
+variable "merge_existing_bucket_policy" {
+  type        = bool
+  default     = true
+  description = "When manage_bucket_policy is `true`, read the bucket's current policy and merge into it instead of replacing it. Set to `false` only for a bucket that has no policy at all — the read fails otherwise."
+}
+
+variable "manage_kms_key_policy" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to let Terraform own the KMS key policy of s3_bucket_kms_key_arn. Requires existing_kms_key_policy_json. Leave `false` to take the statement from the outputs instead."
+}
+
+variable "existing_kms_key_policy_json" {
+  type        = string
+  default     = null
+  description = "Current policy of s3_bucket_kms_key_arn, merged with the CXM decrypt statement. Required when manage_kms_key_policy is `true`: the AWS provider exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable."
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map/dictionary of Tags to be assigned to created resources"


### PR DESCRIPTION
## Why

The module grants bucket access with an **identity** policy attached to a role in the
customer's account, trusted from ours with an `sts:ExternalId` condition. That grant does
nothing for querying logs **in place**: Athena reads S3 as the principal that submitted the
query and cannot be handed an assumed-role session, so the customer-account role never
enters the read path and the external ID has no bearing on it. A **resource** policy is
required — a new resource class for this repo.

## ⚠️ Read before applying this to a real KMS key

**The AWS provider exposes no data source for an existing KMS key policy.** `data.aws_kms_key`
has no `policy` attribute and `data.aws_kms_key_policy` does not exist — verified against the
provider schema, not assumed. `aws_kms_key_policy` replaces the **whole** key policy, and a key
policy replaced without its administrative statements **locks the key permanently** — no
rotation, no deletion, no policy edit, by anyone.

So `manage_kms_key_policy = true` **requires** `existing_kms_key_policy_json`, enforced by a
`lifecycle precondition` that fails the plan with an explicit message rather than silently
defaulting to a policy that contains only our statement. If you are testing this against a key
you care about, read the current policy first (`aws kms get-key-policy`) and pass it in.

The default mode does not touch the key at all — it only renders the statement for you to merge.

## The grant

Account-delegated principal (`arn:aws:iam::${var.cxm_aws_account_id}:root`, already the
default principal of `terraform-aws-iam-role`), narrowed by object prefix, never by role
name — submitting roles are named per tenant and per service, so naming them would break
the customer's policy on any rename.

| Sid | Action | Resource | Condition |
|-----|--------|----------|-----------|
| `CxMInPlaceGetObject` | `s3:GetObject` | `arn:aws:s3:::<bucket>/AWSLogs/*` | — |
| `CxMInPlaceListBucket` | `s3:ListBucket` | `arn:aws:s3:::<bucket>` | `StringLike s3:prefix = AWSLogs/*` |
| `CxMInPlaceGetBucketLocation` | `s3:GetBucketLocation` | `arn:aws:s3:::<bucket>` | — |

Plus a KMS key policy statement granting `kms:Decrypt` + `kms:DescribeKey`
(`kms:GenerateDataKey` is write-side only and excluded). The identity-policy `kms:Decrypt`
already in the module does not substitute for a key policy.

Two constraints are load-bearing and are pinned by comments in the code and by tests:

- **Three separate statements are mandatory.** `s3:GetBucketLocation` does not support the
  `s3:prefix` condition key, so a combined statement is rejected as `MalformedPolicy` — and
  a rejected `put-bucket-policy` leaves the previous policy live, which reads as a passing
  test.
- **No `aws:CalledVia: athena.amazonaws.com` condition.** Athena does not populate
  `CalledVia` on its scan requests, so the condition denies Athena itself.

## Default vs opt-in

`aws_s3_bucket_policy` replaces the **whole** policy, and CloudTrail / VPC Flow Logs buckets
always already carry AWS log-delivery statements. Owning their policy from this module would
silently destroy the customer's log delivery. So the delivery is split by bucket type:

- **Default — no Terraform ownership.** The module creates no bucket or key policy resource.
  It renders the statements as outputs (`inplace_query_bucket_policy_statements_json`,
  `inplace_query_kms_key_policy_statement_json`), surfaced at the root module as maps keyed
  by data source, with a documented snippet to merge into the existing policy. `terraform
  plan` on a bucket that already has a policy shows nothing to change.
- **Opt-in — merge, never clobber.** `manage_bucket_policy = true` (default `false`) builds
  the policy through `data.aws_iam_policy_document.source_policy_documents` seeded from
  `data.aws_s3_bucket_policy`, so pre-existing statements survive and re-applies are
  idempotent (our Sids merge onto themselves). `merge_existing_bucket_policy` (default
  `true`) exists only to skip the read on a bucket that has no policy at all.

The opt-in flag lives on the `terraform-aws-s3-bucket-read` submodule and is deliberately
**not** plumbed through the root module: every bucket the root module touches is a
CUR/CloudTrail/Flow Logs bucket, i.e. exactly the kind whose policy we must not own.

## Validation

- `terraform validate` passes on the root module (through a consumer harness supplying the
  four provider aliases) and on the submodule; `terraform fmt`, `tflint` and `terraform-docs`
  pre-commit hooks pass.
- `terraform test` in `terraform-aws-s3-bucket-read/tests/` — 2 passing runs:
  - default mode creates neither `aws_s3_bucket_policy` nor `aws_kms_key_policy`, renders
    exactly the three Sids in order, carries the `s3:prefix` condition, uses the account
    principal, contains no `CalledVia`, and grants exactly decrypt + describe on KMS;
  - merge mode, with `data.aws_s3_bucket_policy` overridden to a bucket seeded with an
    `AWSLogDeliveryWrite` statement, produces a 4-statement policy that still contains
    `AWSLogDeliveryWrite`.
- Rendered statements inspected via an offline plan; output matches the contract byte for
  byte.

Not validated here: the end-to-end Athena probe against a real bucket — that needs a live
account and is the reviewer's apply-and-probe step.

## Scope

Additive only. No existing variable default, resource name or output changes, so
`terraform plan` on a current deployment shows no diff until one of the new flags is set.

Closes CLO-6645.
