### PR TITLE
fix(eks): point cluster enablement at the member-account asset-crawler role

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -440,17 +440,57 @@ The module automatically detects whether your cluster supports modern **EKS acce
 - [ ] EKS cluster exists
 - [ ] Kubernetes provider configured to authenticate with the cluster
 
+### Which IAM role to grant access to
+
+> **This is the single most common mistake — read it before writing any HCL.**
+>
+> CXM reaches your cluster through a **two-hop assume-role chain**:
+>
+> 1. **Hop 1** — CXM assumes the **organization crawler** in your management account. Used only to enumerate the Organization.
+> 2. **Hop 2** — from that session, CXM assumes the **asset crawler** in the account that owns the cluster. **This is the identity that authenticates to the Kubernetes API server.**
+>
+> The EKS access entry must therefore name the **asset-crawler role in the cluster's own account**, exposed as the `cxm_eks_iam_role_name` output.
+>
+> Granting the access entry to the organization crawler instead looks correct — the role exists, the policy attaches, `terraform apply` succeeds — but every crawl then fails at runtime with:
+>
+> ```
+> namespaces is forbidden: User "arn:aws:iam::<cluster-account>:role/cxm-asset-crawler"
+> cannot list resource "namespaces" in API group "" at the cluster scope
+> ```
+>
+> Note that the error names the role that *should* have had the entry.
+>
+> | Deployment | Role to use | Lives in |
+> |---|---|---|
+> | Organization | `cxm-asset-crawler` (`cxm_eks_iam_role_name`) | every member account |
+> | Lone account | the single CXM role (`cxm_eks_iam_role_name`) | that account |
+>
+> Do not use `cxm_iam_role_name` here — for an Organization deployment that is the hop-1 organization crawler.
+
 ### Step 1: Add the EKS enablement module
 
-Add this alongside your existing CXM integration:
+Add this alongside your existing CXM integration. The module's `aws` provider must point at **the account that owns the cluster**, not the management account:
 
 ```hcl
+# Provider for the account owning the cluster. In an Organization deployment this is a
+# member account, so assume into it. For a lone-account deployment, drop the assume_role.
+provider "aws" {
+  alias  = "cluster_account"
+  region = var.aws_region
+
+  assume_role {
+    role_arn = "arn:aws:iam::${var.cluster_account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
 data "aws_eks_cluster" "my_cluster" {
-  name = "my-production-cluster"
+  provider = aws.cluster_account
+  name     = "my-production-cluster"
 }
 
 data "aws_eks_cluster_auth" "my_cluster" {
-  name = "my-production-cluster"
+  provider = aws.cluster_account
+  name     = "my-production-cluster"
 }
 
 provider "kubernetes" {
@@ -462,8 +502,15 @@ provider "kubernetes" {
 module "cxm_eks_enablement" {
   source = "cxmlabs/cxm-integration/aws//terraform-aws-eks-cluster-enablement"
 
+  providers = {
+    aws        = aws.cluster_account
+    kubernetes = kubernetes
+  }
+
   cluster_name = "my-production-cluster"
-  iam_role_arn = module.cxm_integration.cxm_iam_role_name
+
+  # The asset-crawler role, resolved in the cluster's own account. See the note above.
+  iam_role_arn = module.cxm_integration.cxm_eks_iam_role_name
 
   tags = {
     "ManagedBy" = "terraform"
@@ -491,6 +538,30 @@ Check these outputs:
 - `access_entry_created` - Should be `true` for modern clusters
 - `aws_auth_configmap_updated` - Should be `true` for legacy clusters
 
+Then confirm the entry landed on the right principal — this is what catches the mistake described above:
+
+```bash
+# Run against the CLUSTER'S account. The principal must be the asset-crawler
+# in THIS account, not a role from the management account.
+aws eks list-access-entries --cluster-name my-production-cluster
+
+aws eks describe-access-entry \
+  --cluster-name my-production-cluster \
+  --principal-arn arn:aws:iam::<cluster-account-id>:role/cxm-asset-crawler
+```
+
+If `describe-access-entry` returns `ResourceNotFoundException` for the asset-crawler while `list-access-entries` shows an organization-crawler ARN from a different account, the wrong role was granted access. Create the correct entry and remove the wrong one:
+
+```bash
+aws eks create-access-entry --cluster-name my-production-cluster \
+  --principal-arn arn:aws:iam::<cluster-account-id>:role/cxm-asset-crawler --type STANDARD
+
+aws eks associate-access-policy --cluster-name my-production-cluster \
+  --principal-arn arn:aws:iam::<cluster-account-id>:role/cxm-asset-crawler \
+  --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy \
+  --access-scope type=cluster
+```
+
 ### Namespace-scoped access (optional)
 
 To restrict CXM to specific namespaces instead of cluster-wide access:
@@ -499,8 +570,13 @@ To restrict CXM to specific namespaces instead of cluster-wide access:
 module "cxm_eks_enablement" {
   source = "cxmlabs/cxm-integration/aws//terraform-aws-eks-cluster-enablement"
 
+  providers = {
+    aws        = aws.cluster_account
+    kubernetes = kubernetes
+  }
+
   cluster_name            = "my-production-cluster"
-  iam_role_arn            = module.cxm_integration.cxm_iam_role_name
+  iam_role_arn            = module.cxm_integration.cxm_eks_iam_role_name
   access_scope_type       = "namespace"
   access_scope_namespaces = ["monitoring", "logging", "kube-system"]
 }

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -451,14 +451,7 @@ The module automatically detects whether your cluster supports modern **EKS acce
 >
 > The EKS access entry must therefore name the **asset-crawler role in the cluster's own account**, exposed as the `cxm_eks_iam_role_name` output.
 >
-> Granting the access entry to the organization crawler instead looks correct — the role exists, the policy attaches, `terraform apply` succeeds — but every crawl then fails at runtime with:
->
-> ```
-> namespaces is forbidden: User "arn:aws:iam::<cluster-account>:role/cxm-asset-crawler"
-> cannot list resource "namespaces" in API group "" at the cluster scope
-> ```
->
-> Note that the error names the role that *should* have had the entry.
+> Granting the access entry to the organization crawler instead looks correct — the role exists, the policy attaches, `terraform apply` succeeds, and nothing reports an error. The mistake surfaces only as Kubernetes data never appearing in CXM. Confirm the entry with the [verification step](#step-3-verify) rather than waiting to find out.
 >
 > | Deployment | Role to use | Lives in |
 > |---|---|---|

--- a/README.md
+++ b/README.md
@@ -132,13 +132,23 @@ For enabling CXM access to existing EKS clusters, use the dedicated EKS cluster 
 module "cxm_eks_enablement" {
   source = "./terraform-aws-eks-cluster-enablement"
 
+  # The aws provider MUST point at the account that owns the cluster.
+  providers = {
+    aws        = aws.cluster_account
+    kubernetes = kubernetes
+  }
+
   cluster_name = "my-production-cluster"
-  # Use the IAM role from the CXM integration module
-  iam_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.cxm-integration.iam_role_name}"  # Construct ARN from account ID and role name
+
+  # The asset-crawler role, which lives in the cluster's own account. This is the identity
+  # that reaches the Kubernetes API server. Do NOT use cxm_iam_role_name - in an
+  # Organization deployment that is the management account's organization crawler, which is
+  # only the first hop of the assume-role chain.
+  iam_role_arn = module.cxm-integration.cxm_eks_iam_role_name
 }
 ```
 
-This module automatically detects whether your EKS cluster supports modern access entries or requires the legacy aws-auth ConfigMap approach. The `cxm_iam_role_arn` output automatically selects the appropriate IAM role based on your deployment type (lone account vs organization). For detailed usage instructions, examples, and configuration options, see the [EKS cluster enablement module documentation](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-eks-cluster-enablement).
+This module automatically detects whether your EKS cluster supports modern access entries or requires the legacy aws-auth ConfigMap approach. The `cxm_eks_iam_role_name` output selects the appropriate IAM role for your deployment type: the member-account asset-crawler for an Organization, the single role for a lone account. Getting this role wrong is the most common integration failure — `terraform apply` succeeds and the crawl then fails at runtime — so see the [EKS section of the deployment guide](https://github.com/cxmlabs/terraform-aws-cxm-integration/blob/main/GUIDE.md#which-iam-role-to-grant-access-to) for the reasoning, and the [EKS cluster enablement module documentation](https://github.com/cxmlabs/terraform-aws-cxm-integration/tree/main/terraform-aws-eks-cluster-enablement) for full options.
 
 ### About providers
 
@@ -253,7 +263,9 @@ provider "aws" {
 | ---- | ----------- |
 | lone_account_iam_role_arn | ARN of the CXM IAM role for lone account deployment |
 | organization_iam_role_arn | ARN of the CXM IAM role for organization root deployment |
-| cxm_iam_role_name | Name of the CXM IAM role (automatically selects between lone account or organization deployment) |
+| cxm_iam_role_name | Name of the CXM IAM role deployed in the root account (organization crawler, or the lone-account role). NOT the role to use for EKS cluster enablement in an Organization deployment - see cxm_eks_iam_role_name. |
+| cxm_eks_iam_role_name | Name of the CXM IAM role to grant EKS cluster access to. Deployed in every member account (Organization) or in the single account (lone account). Pass this to terraform-aws-eks-cluster-enablement, resolved against the cluster's own account. |
+| member_account_iam_role_name | Name of the CXM asset-crawler IAM role deployed by the StackSet into every member account. Null for lone-account deployments. |
 | root_account_id | AWS account ID used for the root (management or lone account) deployment |
 | root_region | AWS region used for the root deployment (organization crawler and EventBridge rules) |
 | cur_account_id | AWS account ID where the CUR reader role is deployed |

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,29 @@ output "cxm_iam_role_name" {
     length(module.enable_lone_account) > 0 ? module.enable_lone_account[0].iam_role_name : null,
     length(module.enable_root_organization) > 0 ? module.enable_root_organization[0].iam_role_name : null
   )
-  description = "Name of the CXM IAM role (automatically selects between lone account or organization deployment)"
+  description = <<-EOT
+    Name of the CXM IAM role deployed in the root account (organization crawler, or the
+    lone-account role). NOT the role to use for EKS cluster enablement in an Organization
+    deployment - see cxm_eks_iam_role_name.
+  EOT
+}
+
+# The role EKS cluster enablement must target. In an Organization deployment the crawler
+# reaches the Kubernetes API as the member-account asset-crawler role (the organization
+# crawler is only the jump role used for the first assume-role hop), so the EKS access
+# entry must name the asset-crawler in the cluster's own account. In a lone-account
+# deployment there is only one role and it is the same one.
+output "cxm_eks_iam_role_name" {
+  value = coalesce(
+    length(module.enable_sub_accounts) > 0 ? module.enable_sub_accounts[0].iam_role_name : null,
+    length(module.enable_lone_account) > 0 ? module.enable_lone_account[0].iam_role_name : null
+  )
+  description = "Name of the CXM IAM role to grant EKS cluster access to. Deployed in every member account (Organization) or in the single account (lone account). Pass this to terraform-aws-eks-cluster-enablement, resolved against the cluster's own account."
+}
+
+output "member_account_iam_role_name" {
+  value       = length(module.enable_sub_accounts) > 0 ? module.enable_sub_accounts[0].iam_role_name : null
+  description = "Name of the CXM asset-crawler IAM role deployed by the StackSet into every member account. Null for lone-account deployments."
 }
 
 # Deployment regions and accounts

--- a/terraform-aws-eks-cluster-enablement/README.md
+++ b/terraform-aws-eks-cluster-enablement/README.md
@@ -39,7 +39,7 @@ module "cxm_eks_enablement" {
   source = "./terraform-aws-eks-cluster-enablement"
 
   cluster_name = "my-production-cluster"
-  iam_role_arn = module.cxm_integration.cxm_iam_role_arn
+  iam_role_arn = module.cxm_integration.cxm_eks_iam_role_name
 
   # Module automatically detects and uses appropriate access method
 
@@ -49,6 +49,17 @@ module "cxm_eks_enablement" {
   }
 }
 ```
+
+> **Which role?** Grant access to the CXM role that lives in **the cluster's own account** —
+> `cxm_eks_iam_role_name`. CXM reaches the Kubernetes API through a two-hop assume-role
+> chain, and it is the second hop (the member-account `cxm-asset-crawler`) that
+> authenticates to the API server. The management account's organization crawler
+> (`cxm_iam_role_name`) is only the first hop; granting it the access entry applies cleanly
+> and then fails at runtime with `namespaces is forbidden: User
+> "arn:aws:iam::<cluster-account>:role/cxm-asset-crawler" cannot list resource "namespaces"`.
+> This module's `aws` provider must also point at the cluster's account; if you pass an ARN
+> from a different account the plan now fails with an explanatory error rather than creating
+> a silently useless access entry.
 
 ### Advanced Usage with Namespace Scoping
 
@@ -123,15 +134,16 @@ To upgrade a legacy cluster to use access entries:
 ### Requirements
 
 | Name | Version |
-|------|---------|
-| terraform | >= 1.0 |
+| ---- | ------- |
+| terraform | >= 1.5 |
 | aws | >= 5.0 |
 | kubernetes | >= 2.20 |
 
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
+| terraform | n/a |
 | aws | 6.13.0 |
 | kubernetes | 2.38.0 |
 
@@ -142,10 +154,12 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_eks_access_entry.cxm_access_entry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_entry) | resource |
 | [aws_eks_access_policy_association.cxm_view_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_policy_association) | resource |
 | [kubernetes_config_map_v1_data.aws_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
+| [terraform_data.iam_role_account_guard](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_role.cxm_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [kubernetes_config_map_v1.aws_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/config_map_v1) | data source |
@@ -153,9 +167,9 @@ No modules.
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | cluster_name | Name of the EKS cluster to configure access for | `string` | n/a | yes |
-| iam_role_arn | ARN or name of the IAM role created by the CXM account enablement module (e.g., output from terraform-aws-account-enablement module) | `string` | n/a | yes |
+| iam_role_arn | ARN or name of the CXM IAM role to grant cluster access to. This MUST be the role that exists in the cluster's own AWS account - it is the identity that reaches the Kubernetes API server.  Organization deployment: use the asset-crawler role deployed into every member account by the StackSet, i.e. the parent module's `cxm_eks_iam_role_name` output. Do NOT use the management account's organization crawler; that role is only the first hop of the assume-role chain and granting it the access entry leaves the crawler unauthorized.  Lone-account deployment: there is a single role and it is the same one - `cxm_eks_iam_role_name` still resolves correctly.  A bare name is accepted and resolved against this module's provider account. If an ARN is supplied its account must match that provider account, otherwise the plan fails. | `string` | n/a | yes |
 | kubernetes_groups | List of Kubernetes groups to assign to the IAM role. Only used for aws-auth ConfigMap method. | `list(string)` | `[]` | no |
 | access_scope_type | Type of access scope for the policy association. Valid values: 'cluster' or 'namespace' | `string` | `"cluster"` | no |
 | access_scope_namespaces | List of namespaces for the access scope when access_scope_type is 'namespace'. Required when access_scope_type is 'namespace'. | `list(string)` | `[]` | no |
@@ -164,7 +178,7 @@ No modules.
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | cluster_name | Name of the EKS cluster that was configured |
 | cluster_endpoint | Endpoint URL of the EKS cluster |
 | cluster_account_id | AWS Account ID where the EKS cluster is located |

--- a/terraform-aws-eks-cluster-enablement/README.md
+++ b/terraform-aws-eks-cluster-enablement/README.md
@@ -55,11 +55,11 @@ module "cxm_eks_enablement" {
 > chain, and it is the second hop (the member-account `cxm-asset-crawler`) that
 > authenticates to the API server. The management account's organization crawler
 > (`cxm_iam_role_name`) is only the first hop; granting it the access entry applies cleanly
-> and then fails at runtime with `namespaces is forbidden: User
-> "arn:aws:iam::<cluster-account>:role/cxm-asset-crawler" cannot list resource "namespaces"`.
-> This module's `aws` provider must also point at the cluster's account; if you pass an ARN
-> from a different account the plan now fails with an explanatory error rather than creating
-> a silently useless access entry.
+> and reports no error, but CXM is then never able to read the cluster. Verify with
+> `aws eks describe-access-entry --cluster-name <cluster> --principal-arn <asset-crawler-arn>`
+> in the cluster's account. This module's `aws` provider must also point at the cluster's
+> account; if you pass an ARN from a different account the plan fails with an explanatory
+> error rather than creating a silently useless access entry.
 
 ### Advanced Usage with Namespace Scoping
 

--- a/terraform-aws-eks-cluster-enablement/examples/basic/main.tf
+++ b/terraform-aws-eks-cluster-enablement/examples/basic/main.tf
@@ -58,7 +58,10 @@ module "cxm_eks_enablement" {
   source = "../.."
 
   cluster_name = var.cluster_name
-  iam_role_arn = module.cxm_integration.cxm_iam_role_arn # Automatically selects the right role
+  # The CXM role that exists in this cluster's own account. For a lone-account deployment
+  # that is the single CXM role; for an Organization it is the member-account asset-crawler.
+  # `cxm_iam_role_arn` is not an output of the parent module - do not use it.
+  iam_role_arn = module.cxm_integration.cxm_eks_iam_role_name
 
   # Module automatically detects cluster capabilities and uses appropriate method
 

--- a/terraform-aws-eks-cluster-enablement/examples/organization-multi-cluster/main.tf
+++ b/terraform-aws-eks-cluster-enablement/examples/organization-multi-cluster/main.tf
@@ -152,8 +152,12 @@ module "cxm_production_eks_enablement" {
   for_each = toset(var.production_cluster_names)
 
   cluster_name = each.value
-  # Construct IAM role ARN from account ID and role name
-  iam_role_arn = "arn:aws:iam::${data.aws_caller_identity.production.account_id}:role/${module.cxm_integration.cxm_iam_role_name}"
+
+  # The member-account asset-crawler. This is the hop-2 identity that authenticates to the
+  # Kubernetes API server. cxm_iam_role_name is the management account's organization
+  # crawler (hop 1) and does not exist in this account - granting it access entries here
+  # leaves every crawl unauthorized at runtime.
+  iam_role_arn = module.cxm_integration.cxm_eks_iam_role_name
 
   # Production clusters get cluster-wide view access
   access_scope_type = "cluster"
@@ -183,8 +187,9 @@ module "cxm_staging_eks_enablement" {
   for_each = toset(var.staging_cluster_names)
 
   cluster_name = each.value
-  # Construct IAM role ARN from account ID and role name
-  iam_role_arn = "arn:aws:iam::${data.aws_caller_identity.staging.account_id}:role/${module.cxm_integration.cxm_iam_role_name}"
+
+  # Member-account asset-crawler - see the note on the production block above.
+  iam_role_arn = module.cxm_integration.cxm_eks_iam_role_name
 
   # Staging clusters get namespace-scoped access for security
   access_scope_type       = "namespace"

--- a/terraform-aws-eks-cluster-enablement/main.tf
+++ b/terraform-aws-eks-cluster-enablement/main.tf
@@ -35,8 +35,13 @@ resource "terraform_data" "iam_role_account_guard" {
   lifecycle {
     precondition {
       condition = local.supplied_role_account_id == null || local.supplied_role_account_id == data.aws_caller_identity.current.account_id
+      # The coalesce is load-bearing: Terraform evaluates a precondition's error_message
+      # template eagerly, even when the condition passes, and interpolating a null is a hard
+      # error. Without it every bare role name - the documented primary usage - fails the plan.
+      # The fallback itself is unreachable: the message only renders when the condition fails,
+      # which requires a non-null supplied_role_account_id.
       error_message = join("", [
-        "iam_role_arn points at account ${local.supplied_role_account_id} but this module is configured against account ${data.aws_caller_identity.current.account_id} (the cluster's account). ",
+        "iam_role_arn points at account ${coalesce(local.supplied_role_account_id, "unknown")} but this module is configured against account ${data.aws_caller_identity.current.account_id} (the cluster's account). ",
         "The EKS access entry must name the CXM role that exists IN THE CLUSTER'S OWN ACCOUNT - that is the identity which reaches the Kubernetes API. ",
         "In an Organization deployment that is the asset-crawler role (see the cxm_eks_iam_role_name output of the parent module), not the management account's organization crawler, which is only used for the first assume-role hop."
       ])

--- a/terraform-aws-eks-cluster-enablement/main.tf
+++ b/terraform-aws-eks-cluster-enablement/main.tf
@@ -2,6 +2,9 @@ locals {
   # Extract role name from ARN if provided as ARN, otherwise use as-is
   iam_role_name = can(regex("^arn:aws:iam::", var.iam_role_arn)) ? element(split("/", var.iam_role_arn), length(split("/", var.iam_role_arn)) - 1) : var.iam_role_arn
 
+  # Account embedded in var.iam_role_arn when an ARN was supplied, else null.
+  supplied_role_account_id = can(regex("^arn:aws:iam::", var.iam_role_arn)) ? split(":", var.iam_role_arn)[4] : null
+
   # Check if the cluster supports access entries (EKS API version 2023-10-14 or later)
   # This is determined by checking if the cluster has the access_config block
   cluster_supports_access_entries = try(data.aws_eks_cluster.cluster.access_config[0].authentication_mode != null, false)
@@ -18,6 +21,27 @@ check "namespace_scope_validation" {
 # Data source to get information about the EKS cluster
 data "aws_eks_cluster" "cluster" {
   name = var.cluster_name
+}
+
+data "aws_caller_identity" "current" {}
+
+# The role is always resolved by NAME in the account this module's aws provider points at
+# (which is the cluster's account). If the caller passes an ARN from a DIFFERENT account -
+# typically the management account's organization crawler - the lookup silently resolves a
+# same-named role in the cluster account instead, or fails with a confusing "role not
+# found". Either way the resulting access entry names the wrong principal and every
+# Kubernetes call is rejected at runtime. Fail loudly at plan time instead.
+resource "terraform_data" "iam_role_account_guard" {
+  lifecycle {
+    precondition {
+      condition = local.supplied_role_account_id == null || local.supplied_role_account_id == data.aws_caller_identity.current.account_id
+      error_message = join("", [
+        "iam_role_arn points at account ${local.supplied_role_account_id} but this module is configured against account ${data.aws_caller_identity.current.account_id} (the cluster's account). ",
+        "The EKS access entry must name the CXM role that exists IN THE CLUSTER'S OWN ACCOUNT - that is the identity which reaches the Kubernetes API. ",
+        "In an Organization deployment that is the asset-crawler role (see the cxm_eks_iam_role_name output of the parent module), not the management account's organization crawler, which is only used for the first assume-role hop."
+      ])
+    }
+  }
 }
 
 # Data source to get the IAM role information

--- a/terraform-aws-eks-cluster-enablement/tests/iam_role_account_guard.tftest.hcl
+++ b/terraform-aws-eks-cluster-enablement/tests/iam_role_account_guard.tftest.hcl
@@ -1,0 +1,94 @@
+# Guards the failure mode that silently breaks a customer's EKS crawl: an iam_role_arn from a
+# different account than the cluster's. The role is always resolved by NAME in this module's
+# provider account, so a foreign ARN either resolves a same-named local role or fails with a
+# confusing "not found" - and the access entry ends up naming the wrong principal.
+#
+# The bare-name run also pins a regression: the guard's error_message is evaluated eagerly by
+# Terraform even when the condition passes, so interpolating the null account id there fails
+# every plan that supplies a bare role name. Do not remove the coalesce in main.tf.
+#
+# The providers are mocked so the plan is hermetic: no credentials, no network, and a caller
+# identity we control so the guard can be exercised deterministically.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "111111111111"
+    }
+  }
+
+  mock_data "aws_eks_cluster" {
+    defaults = {
+      arn      = "arn:aws:eks:eu-west-1:111111111111:cluster/example-cluster"
+      endpoint = "https://example.eks.eu-west-1.amazonaws.com"
+      # Non-null authentication_mode is what makes the module take the access-entry path
+      # instead of the legacy aws-auth ConfigMap path.
+      access_config = [{
+        authentication_mode                         = "API_AND_CONFIG_MAP"
+        bootstrap_cluster_creator_admin_permissions = true
+      }]
+    }
+  }
+
+  mock_data "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111111111111:role/cxm-asset-crawler"
+    }
+  }
+}
+
+mock_provider "kubernetes" {}
+
+variables {
+  cluster_name = "example-cluster"
+  iam_role_arn = "cxm-asset-crawler"
+}
+
+run "bare_role_name_is_resolved_against_the_provider_account" {
+  command = plan
+
+  assert {
+    condition     = length(aws_eks_access_entry.cxm_access_entry) == 1
+    error_message = "A cluster advertising an authentication_mode must get an access entry, not an aws-auth ConfigMap edit."
+  }
+
+  assert {
+    condition     = aws_eks_access_entry.cxm_access_entry[0].user_name == "cxm-asset-crawler"
+    error_message = "A bare name must be used as-is when looking the role up in the cluster account."
+  }
+
+  assert {
+    condition     = aws_eks_access_entry.cxm_access_entry[0].principal_arn == "arn:aws:iam::111111111111:role/cxm-asset-crawler"
+    error_message = "The access entry must name the role resolved in the cluster's own account."
+  }
+}
+
+run "arn_from_the_cluster_account_is_accepted_and_reduced_to_its_role_name" {
+  command = plan
+
+  variables {
+    iam_role_arn = "arn:aws:iam::111111111111:role/cxm-asset-crawler"
+  }
+
+  assert {
+    condition     = aws_eks_access_entry.cxm_access_entry[0].user_name == "cxm-asset-crawler"
+    error_message = "An ARN must be reduced to its role name before the IAM lookup."
+  }
+
+  assert {
+    condition     = aws_eks_access_entry.cxm_access_entry[0].principal_arn == "arn:aws:iam::111111111111:role/cxm-asset-crawler"
+    error_message = "A same-account ARN must produce an access entry for that same role."
+  }
+}
+
+run "arn_from_another_account_fails_the_plan" {
+  command = plan
+
+  variables {
+    # Typically the management account's organization crawler, which only performs the first
+    # assume-role hop and never reaches the Kubernetes API itself.
+    iam_role_arn = "arn:aws:iam::222222222222:role/cxm-organization-crawler"
+  }
+
+  expect_failures = [terraform_data.iam_role_account_guard]
+}

--- a/terraform-aws-eks-cluster-enablement/variables.tf
+++ b/terraform-aws-eks-cluster-enablement/variables.tf
@@ -7,7 +7,22 @@ variable "cluster_name" {
 
 variable "iam_role_arn" {
   type        = string
-  description = "ARN or name of the IAM role created by the CXM account enablement module (e.g., output from terraform-aws-account-enablement module)"
+  description = <<-EOT
+    ARN or name of the CXM IAM role to grant cluster access to. This MUST be the role that
+    exists in the cluster's own AWS account - it is the identity that reaches the Kubernetes
+    API server.
+
+    Organization deployment: use the asset-crawler role deployed into every member account
+    by the StackSet, i.e. the parent module's `cxm_eks_iam_role_name` output. Do NOT use the
+    management account's organization crawler; that role is only the first hop of the
+    assume-role chain and granting it the access entry leaves the crawler unauthorized.
+
+    Lone-account deployment: there is a single role and it is the same one -
+    `cxm_eks_iam_role_name` still resolves correctly.
+
+    A bare name is accepted and resolved against this module's provider account. If an ARN
+    is supplied its account must match that provider account, otherwise the plan fails.
+  EOT
 }
 
 # Optional Variables

--- a/terraform-aws-eks-cluster-enablement/versions.tf
+++ b/terraform-aws-eks-cluster-enablement/versions.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.0"
+  # 1.5+ for `check` blocks, which this module already relied on while declaring >= 1.0.
+  required_version = ">= 1.5"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Problem

The EKS cluster enablement module and its docs steer users to grant the EKS access entry to the **wrong IAM role**. The failure is silent at apply time and only surfaces later as a runtime crawl failure, which makes it expensive to diagnose.

CXM reaches a customer's Kubernetes API through a two-hop assume-role chain:

1. **Hop 1** — assume the organization crawler in the management account (enumerate the Organization).
2. **Hop 2** — from that session, assume the asset-crawler **in the account that owns the cluster**. This is the identity that authenticates to the API server.

The access entry must therefore name the member-account asset-crawler. Granting it to the organization crawler applies cleanly and then fails on every crawl:

```
namespaces is forbidden: User "arn:aws:iam::<cluster-account>:role/cxm-asset-crawler"
cannot list resource "namespaces" in API group "" at the cluster scope
```

This has now bitten a production customer on three clusters. Contributing causes, all in this repo:

- **The correct role was not reachable from the parent module.** `module.enable_sub_accounts.iam_role_name` returns the asset-crawler name but was never exposed as a root output. The only role-name output, `cxm_iam_role_name`, `coalesce`s to the *organization* crawler.
- **`GUIDE.md` told users to pass exactly that**, and additionally passed a bare *name* into a variable called `iam_role_arn`, with no provider override — so the module ran against the management account.
- **`README.md` and the multi-cluster example** built `arn:aws:iam::<member>:role/${cxm_iam_role_name}` — an org-crawler name in a member account, a role that does not exist there.
- **`examples/basic`** referenced `module.cxm_integration.cxm_iam_role_arn`, which is not an output of the parent module at all.
- **The module resolves the role by name against its own provider account**, so an ARN from another account is silently swapped for a same-named local role, or fails with an opaque "role not found".

## Changes

**New outputs** (`outputs.tf`)
- `cxm_eks_iam_role_name` — the role EKS enablement should target. Resolves to the member-account asset-crawler for an Organization, the single role for a lone account.
- `member_account_iam_role_name` — the StackSet-deployed asset-crawler name; null for lone-account deployments.
- `cxm_iam_role_name` description now states plainly that it is not the EKS role for an Organization deployment.

**Plan-time guard** (`terraform-aws-eks-cluster-enablement/main.tf`)
- A `terraform_data` precondition fails the plan when `iam_role_arn` carries an account id that differs from the module's provider account, naming the correct role in the error. This converts the silent misconfiguration into a hard stop.
- `versions.tf` bumped `>= 1.0` → `>= 1.5`, matching what the pre-existing `check` block already required.

**Docs**
- `GUIDE.md` — new "Which IAM role to grant access to" section explaining the two-hop chain with the runtime error it produces; the example now shows an explicit cluster-account provider and uses `cxm_eks_iam_role_name`; verification step now includes `list-access-entries` / `describe-access-entry` plus the CLI remediation.
- `README.md`, module `README.md`, and both examples corrected consistently.
- `terraform-docs` regenerated.

## Testing

- `terraform validate` passes on `terraform-aws-eks-cluster-enablement`.
- `terraform fmt -recursive`, `tflint`, and `terraform-docs` pre-commit hooks all pass.
- Root-module `terraform validate` still reports missing aliased providers — pre-existing on `main` (verified by stashing this branch's changes), since the root module requires callers to pass `aws.root`/`aws.cur`/etc.
- The guard's behaviour was reasoned from the module's existing name-resolution logic; it is not covered by an automated test, as the repo has no test harness.

## Notes for reviewers

- `cxm_iam_role_name` is retained unchanged for backwards compatibility — this PR adds outputs and corrects guidance rather than renaming anything.
- Worth deciding separately whether to publish a short migration note for existing users, since anyone who followed the old GUIDE has a wrong access entry in place today and will not notice until their K8s tables stay empty.
