### PR TITLE
fix: add explicit bedrock read permissions to organization-crawler and account-enablement roles

### DIFF
--- a/terraform-aws-account-enablement/main.tf
+++ b/terraform-aws-account-enablement/main.tf
@@ -101,6 +101,16 @@ data "aws_iam_policy_document" "cxm_read_only_policy" {
   }
 
   statement {
+    # ReadOnlyAccess lags behind newer bedrock list APIs, so grant them explicitly.
+    sid = "BedrockInventoryPermissions"
+    actions = [
+      "bedrock:List*",
+      "bedrock:Get*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
     # Explicitly removing read access to S3 objects
     sid           = "ExplicitDenyOnS3Files"
     effect        = "Deny"

--- a/terraform-aws-organization-enablement/main.tf
+++ b/terraform-aws-organization-enablement/main.tf
@@ -152,6 +152,17 @@ data "aws_iam_policy_document" "cxm_organization_read_only_policy" {
   }
 
   statement {
+    # ReadOnlyAccess lags behind newer bedrock list APIs; the management account's own
+    # assets are inventoried with this role, so it needs the same grant as sub-accounts.
+    sid = "BedrockInventoryPermissions"
+    actions = [
+      "bedrock:List*",
+      "bedrock:Get*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
     # Understand users and groups in the organization
     sid = "SSOReadOnlyAccess"
     actions = [


### PR DESCRIPTION
## Problem

The inventory crawler failed in production on `aws_bedrock_imported_models` and `aws_bedrock_marketplace_model_endpoints`:

```
AccessDeniedException ... assumed-role/cxm-organization-crawler/AssumeRoleSession
is not authorized to perform: bedrock:ListImportedModels
because no identity-based policy allows the bedrock:ListImportedModels action
```

PR #37 added `BedrockInventoryPermissions` to the **asset-crawler** (sub-account) role, because the AWS-managed `ReadOnlyAccess` policy lags behind newer bedrock list APIs. Two roles that carry the same `ReadOnlyAccess` attachment were missed:

- `terraform-aws-organization-enablement` — the org-crawler role. The crawler skips the member-role hop for the management account and uses the org session directly, so the management account's own bedrock assets are read with **this** role.
- `terraform-aws-account-enablement` — the lone-account role, which is the only role in a single-account (non-organization) integration.

## Change

Adds the same `BedrockInventoryPermissions` statement (`bedrock:List*`, `bedrock:Get*`, `Resource: "*"`) to both modules. Identical to the block already present in `terraform-aws-sub-account-cxm-enablement/policies.tf` and `terraform-aws-full-organization-enablement/cxm-aws-account-enablement.yaml`.

The CloudFormation templates in `cloudformation-aws-cxm-integration` already carry this statement on both the root and sub-account templates — no change needed there.

## Verification

`terraform fmt`, `terraform validate` + `tflint` pass via pre-commit. After apply, re-run the failing inventory partition and confirm rows land in `inventory_<tenant>_<org>.aws_bedrock_imported_models`.