### PR TITLE
Grant the org crawler read access to RI/SP discount-sharing preferences

### DIFF
--- a/terraform-aws-organization-enablement/main.tf
+++ b/terraform-aws-organization-enablement/main.tf
@@ -90,6 +90,8 @@ data "aws_iam_policy_document" "cxm_organization_read_only_policy" {
       "ce:Describe*",
       "ce:Get*",
       "ce:List*",
+      # Authoritative per-account RI/SP discount-sharing toggle (CUR can only infer it)
+      "billing:GetBillingPreferences",
       "ec2:DescribeRegions",
       "ec2:DescribeAccountAttributes",
     ]


### PR DESCRIPTION
## Why

RI/SP discount sharing is a per-account billing preference on the payer account. Today the platform infers it from the cost and usage report by counting non-owner beneficiaries, which reports an account as isolated whenever a shared commitment simply happened to be fully consumed by its owner. `billing:GetBillingPreferences` returns the toggle itself, so the inference — and its false positives — go away.

## What

One read-only action appended to the existing `MonitorReportDefinitions` statement on the organization-crawler role.

The action is not covered by the attached AWS-managed `ReadOnlyAccess` policy (AWS keeps fine-grained billing reads in `AWSBillingReadOnlyAccess`), so it has to be granted explicitly.

## Scope

Organization module only. The crawler reads this once per organization through the org-crawler role and skips lone-account datasources entirely, so the member-account roles (`terraform-aws-account-enablement`, the StackSet CloudFormation template, `terraform-aws-sub-account-cxm-enablement`) are untouched.

No new variables or outputs, so no README regeneration. `terraform fmt -recursive -check` is clean.

## Rollout

Read-only and additive — safe to apply at any time. Until a customer re-applies the module the crawler treats the denial as a missing permission: it keeps the previous snapshot, raises a user-facing "integration is missing required permissions" event, and skips the run.