### PR TITLE
Let several CXM accounts read one log bucket, additively

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -751,14 +751,14 @@ output:
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "CxMInPlaceGetObject",
+      "Sid": "CxMInPlaceGetObjectREPLACE_WITH_CXM_ACCOUNT_ID",
       "Effect": "Allow",
       "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
       "Action": "s3:GetObject",
       "Resource": "arn:aws:s3:::REPLACE_WITH_BUCKET_NAME/AWSLogs/*"
     },
     {
-      "Sid": "CxMInPlaceListBucket",
+      "Sid": "CxMInPlaceListBucketREPLACE_WITH_CXM_ACCOUNT_ID",
       "Effect": "Allow",
       "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
       "Action": "s3:ListBucket",
@@ -766,7 +766,7 @@ output:
       "Condition": { "StringLike": { "s3:prefix": "AWSLogs/*" } }
     },
     {
-      "Sid": "CxMInPlaceGetBucketLocation",
+      "Sid": "CxMInPlaceGetBucketLocationREPLACE_WITH_CXM_ACCOUNT_ID",
       "Effect": "Allow",
       "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
       "Action": "s3:GetBucketLocation",
@@ -780,7 +780,7 @@ And the key grant:
 
 ```json
 {
-  "Sid": "CxMInPlaceDecrypt",
+  "Sid": "CxMInPlaceDecryptREPLACE_WITH_CXM_ACCOUNT_ID",
   "Effect": "Allow",
   "Principal": { "AWS": "arn:aws:iam::REPLACE_WITH_CXM_ACCOUNT_ID:root" },
   "Action": ["kms:Decrypt", "kms:DescribeKey"],
@@ -788,7 +788,7 @@ And the key grant:
 }
 ```
 
-Three points worth keeping when you adapt this:
+Four points worth keeping when you adapt this:
 
 - **Keep the three statements separate.** `s3:GetBucketLocation` does not support the
   `s3:prefix` condition key, so folding it in with `s3:ListBucket` makes AWS reject the
@@ -799,6 +799,11 @@ Three points worth keeping when you adapt this:
 - **The principal is the CXM account, not a role.** Access is narrowed by object prefix
   instead. Our submitting roles are named per tenant and per service, so naming them would
   break your policy every time one is renamed.
+- **The account id in each `Sid` is deliberate.** A bucket read by more than one CXM
+  environment carries one statement set per reader. S3 does accept two statements sharing a
+  `Sid`, but nothing can tell them apart afterwards — revoking one reader would mean
+  rewriting the other's grant too — and Terraform's own policy merge refuses a duplicate
+  `Sid` outright. Keep the suffix, and merge rather than replace.
 
 ### Opt-in mode: let Terraform own the policy
 
@@ -838,6 +843,32 @@ module "cxm_dedicated_bucket" {
 > an out-of-band *removal* of a CXM statement is silently restored and vice versa. Keep a
 > single owner per bucket policy.
 
+### Several CXM environments reading one bucket
+
+CXM may analyse the same bucket from more than one account — a staging environment
+alongside production, for example. Each reader needs its own trust statement, because
+external IDs are per environment and a single `StringEquals` with several values is an OR
+that would let any reader in with any external ID.
+
+Declare the extra readers instead of deploying a second stack:
+
+```hcl
+module "cxm_integration" {
+  # ...
+  cxm_aws_account_id = "REPLACE_WITH_CXM_ACCOUNT_ID"
+  cxm_external_id    = "REPLACE_WITH_CXM_EXTERNAL_ID"
+
+  additional_cxm_readers = [
+    { account_id = "REPLACE_WITH_SECOND_CXM_ACCOUNT_ID", external_id = "REPLACE_WITH_SECOND_EXTERNAL_ID" },
+  ]
+}
+```
+
+Each entry adds one trust statement on every reader role and one in-place statement set,
+`Sid`-suffixed with its account id, to the rendered bucket and key policies. Additional
+readers are always account-delegated (`:root`); `cxm_role_name` narrows the primary reader
+only.
+
 ---
 
 ## Optional Configuration
@@ -859,6 +890,7 @@ These variables can be added to any scenario above:
 | `flowlogs_bucket_name` | `null` | S3 bucket storing centralized VPC Flow Logs (required when Flow Logs analysis is enabled) |
 | `flowlogs_kms_key_arn` | `null` | KMS key ARN for encrypted Flow Logs data in S3 |
 | `enable_scheduling` | `false` | Enable scheduling and scaling permissions for FinOps cost optimization |
+| `additional_cxm_readers` | `[]` | Extra CXM accounts reading the same buckets, each with its own external ID (see [Several CXM environments reading one bucket](#several-cxm-environments-reading-one-bucket)) |
 ### Example with optional variables
 
 ```hcl

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ provider "aws" {
 | prefix | Optional - prefix for key constructs created by this module. | `string` | `"cxm"` | no |
 | role_suffix | Optional - suffix to append to roles names. | `string` | `null` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
+| additional_cxm_readers | Extra Cloud ex Machina accounts that read the CUR, CloudTrail and Flow Logs buckets, each with its own external ID. Provided by CXM when more than one CXM tenant analyses the same buckets: each entry adds a trust statement on the reader roles and an in-place query statement set on the buckets. | ```list(object({ account_id = string external_id = string }))``` | `[]` | no |
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -74,11 +74,12 @@ module "enable_cur" {
   iam_role_external_id = var.cxm_external_id
   prefix               = local.prefix
   # This role name will be prefixed by local.prefix when deployed
-  iam_role_name         = "cur-reader${local.role_suffix}"
-  cxm_aws_account_id    = var.cxm_aws_account_id
-  s3_bucket_name        = var.cost_usage_report_bucket_name
-  s3_bucket_kms_key_arn = var.s3_kms_key_arn
-  tags                  = local.tags
+  iam_role_name          = "cur-reader${local.role_suffix}"
+  cxm_aws_account_id     = var.cxm_aws_account_id
+  additional_cxm_readers = var.additional_cxm_readers
+  s3_bucket_name         = var.cost_usage_report_bucket_name
+  s3_bucket_kms_key_arn  = var.s3_kms_key_arn
+  tags                   = local.tags
 }
 
 # CLOUDTRAIL
@@ -94,11 +95,12 @@ module "enable_cloudtrail" {
   iam_role_external_id = var.cxm_external_id
   prefix               = local.prefix
   # This role name will be prefixed by local.prefix when deployed
-  iam_role_name         = "cloudtrail-reader${local.role_suffix}"
-  cxm_aws_account_id    = var.cxm_aws_account_id
-  s3_bucket_name        = var.cloudtrail_bucket_name
-  s3_bucket_kms_key_arn = var.s3_kms_key_arn
-  tags                  = local.tags
+  iam_role_name          = "cloudtrail-reader${local.role_suffix}"
+  cxm_aws_account_id     = var.cxm_aws_account_id
+  additional_cxm_readers = var.additional_cxm_readers
+  s3_bucket_name         = var.cloudtrail_bucket_name
+  s3_bucket_kms_key_arn  = var.s3_kms_key_arn
+  tags                   = local.tags
 }
 
 # VPC FLOW LOGS
@@ -114,9 +116,10 @@ module "enable_flowlogs" {
   iam_role_external_id = var.cxm_external_id
   prefix               = local.prefix
   # This role name will be prefixed by local.prefix when deployed
-  iam_role_name         = "flowlogs-reader${local.role_suffix}"
-  cxm_aws_account_id    = var.cxm_aws_account_id
-  s3_bucket_name        = var.flowlogs_bucket_name
-  s3_bucket_kms_key_arn = var.flowlogs_kms_key_arn
-  tags                  = local.tags
+  iam_role_name          = "flowlogs-reader${local.role_suffix}"
+  cxm_aws_account_id     = var.cxm_aws_account_id
+  additional_cxm_readers = var.additional_cxm_readers
+  s3_bucket_name         = var.flowlogs_bucket_name
+  s3_bucket_kms_key_arn  = var.flowlogs_kms_key_arn
+  tags                   = local.tags
 }

--- a/terraform-aws-iam-role/README.md
+++ b/terraform-aws-iam-role/README.md
@@ -11,7 +11,7 @@ This is a sub module that creates a role that only CXM can use.
 ### Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.5.0 |
 | aws | >= 3.74.0 |
 | random | >= 2.1 |
@@ -19,7 +19,7 @@ This is a sub module that creates a role that only CXM can use.
 ### Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | aws | >= 3.74.0 |
 
 ### Modules
@@ -29,14 +29,14 @@ No modules.
 ### Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_role.cxm_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_policy_document.cxm_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | iam_role_name | The IAM role name to create. | `string` | n/a | yes |
 | external_id | External ID provided by Cloud ex Machina to configure the role. | `string` | n/a | yes |
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access. | `string` | n/a | yes |
@@ -44,11 +44,12 @@ No modules.
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources. | `map(string)` | `{}` | no |
 | dry_run | Setting dry_run to `true` will prevent the module from creating new resources. | `bool` | `false` | no |
+| additional_cxm_readers | Extra Cloud ex Machina accounts allowed to assume this role, each with its own external ID. One trust statement is added per entry, so several CXM tenants can read the same bucket without a role per tenant. | ```list(object({ account_id = string external_id = string }))``` | `[]` | no |
 
 ### Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | created | Indicates if the resources specified in the module were created or not. |
 | name | IAM Role Name. |
 | arn | IAM Role ARN. |

--- a/terraform-aws-iam-role/main.tf
+++ b/terraform-aws-iam-role/main.tf
@@ -1,25 +1,45 @@
 locals {
   principal = var.cxm_role_name != null ? "arn:aws:iam::${var.cxm_aws_account_id}:role/${var.cxm_role_name}" : "arn:aws:iam::${var.cxm_aws_account_id}:root"
+
+  # One statement per reader: external IDs differ per CXM tenant, and a single StringEquals
+  # condition with several values is an OR that would let any reader use any external ID.
+  # Additional readers are always account-delegated (:root) — cxm_role_name narrows the
+  # primary reader only.
+  additional_principals = [
+    for reader in var.additional_cxm_readers : {
+      principal   = "arn:aws:iam::${reader.account_id}:root"
+      external_id = reader.external_id
+    }
+  ]
+  trusted_readers = concat(
+    [{ principal = local.principal, external_id = var.external_id }],
+    local.additional_principals,
+  )
 }
 
 
 data "aws_iam_policy_document" "cxm_assume_role_policy" {
   count   = var.dry_run ? 0 : 1
   version = "2012-10-17"
-  statement {
-    actions = ["sts:AssumeRole"]
 
-    principals {
-      type = "AWS"
-      identifiers = [
-        local.principal
-      ]
-    }
+  dynamic "statement" {
+    for_each = local.trusted_readers
 
-    condition {
-      test     = "StringEquals"
-      variable = "sts:ExternalId"
-      values   = [var.external_id]
+    content {
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type = "AWS"
+        identifiers = [
+          statement.value.principal
+        ]
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [statement.value.external_id]
+      }
     }
   }
 }

--- a/terraform-aws-iam-role/main.tf
+++ b/terraform-aws-iam-role/main.tf
@@ -1,10 +1,8 @@
 locals {
   principal = var.cxm_role_name != null ? "arn:aws:iam::${var.cxm_aws_account_id}:role/${var.cxm_role_name}" : "arn:aws:iam::${var.cxm_aws_account_id}:root"
 
-  # One statement per reader: external IDs differ per CXM tenant, and a single StringEquals
-  # condition with several values is an OR that would let any reader use any external ID.
-  # Additional readers are always account-delegated (:root) — cxm_role_name narrows the
-  # primary reader only.
+  # One statement per reader: StringEquals with several external IDs is an OR, letting any
+  # reader in with any ID. Additional readers are :root; cxm_role_name narrows the primary.
   additional_principals = [
     for reader in var.additional_cxm_readers : {
       principal   = "arn:aws:iam::${reader.account_id}:root"

--- a/terraform-aws-iam-role/variables.tf
+++ b/terraform-aws-iam-role/variables.tf
@@ -36,3 +36,12 @@ variable "dry_run" {
   default     = false
   description = "Setting dry_run to `true` will prevent the module from creating new resources."
 }
+
+variable "additional_cxm_readers" {
+  type = list(object({
+    account_id  = string
+    external_id = string
+  }))
+  default     = []
+  description = "Extra Cloud ex Machina accounts allowed to assume this role, each with its own external ID. One trust statement is added per entry, so several CXM tenants can read the same bucket without a role per tenant."
+}

--- a/terraform-aws-s3-bucket-read/README.md
+++ b/terraform-aws-s3-bucket-read/README.md
@@ -20,8 +20,8 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 
 | Name | Version |
 | ---- | ------- |
-| random | 3.9.0 |
-| aws | 6.58.0 |
+| random | >= 2.1 |
+| aws | >= 3.74.0 |
 
 ### Modules
 
@@ -76,6 +76,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | manage_kms_key_policy | Set to `true` to let Terraform own the KMS key policy of s3_bucket_kms_key_arn. Requires existing_kms_key_policy_json. Leave `false` to take the statement from the outputs instead. | `bool` | `false` | no |
 | existing_kms_key_policy_json | Current policy of s3_bucket_kms_key_arn, merged with the CXM decrypt statement. Required when manage_kms_key_policy is `true`: the AWS provider exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable. | `string` | `null` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
+| additional_cxm_readers | Extra Cloud ex Machina accounts that read this bucket, each with its own external ID. Adds a trust statement on the reader role and an in-place query statement set on the bucket (and key) per entry, so several CXM tenants can share one bucket. | ```list(object({ account_id = string external_id = string }))``` | `[]` | no |
 
 ### Outputs
 

--- a/terraform-aws-s3-bucket-read/inplace-query-access.tf
+++ b/terraform-aws-s3-bucket-read/inplace-query-access.tf
@@ -10,8 +10,18 @@
 locals {
   inplace_object_prefix = "${trimsuffix(var.inplace_query_object_prefix, "/")}/"
   inplace_bucket_arn    = "arn:aws:s3:::${var.s3_bucket_name}"
-  inplace_cxm_principal = "arn:aws:iam::${var.cxm_aws_account_id}:root"
   inplace_kms_statement = var.s3_bucket_kms_key_arn != null || var.manage_kms_key_policy
+
+  # One statement per reader account, with the account id in the Sid. A bucket read by
+  # several CXM tenants gets one statement set each. The suffix is what makes them mergeable:
+  # aws_iam_policy_document rejects a duplicate Sid outright ("Remove the Sid or ensure Sids
+  # are unique"), and while PutBucketPolicy does accept duplicates, two statements sharing a
+  # Sid cannot be told apart afterwards — so one reader's grant could not be updated or
+  # revoked without touching the other's.
+  inplace_reader_accounts = distinct(concat(
+    [var.cxm_aws_account_id],
+    [for reader in var.additional_cxm_readers : reader.account_id],
+  ))
 }
 
 # Three separate statements are mandatory: s3:GetBucketLocation does not support the
@@ -22,42 +32,54 @@ locals {
 data "aws_iam_policy_document" "cxm_inplace_bucket_statements" {
   version = "2012-10-17"
 
-  statement {
-    sid       = "CxMInPlaceGetObject"
-    actions   = ["s3:GetObject"]
-    resources = ["${local.inplace_bucket_arn}/${local.inplace_object_prefix}*"]
+  dynamic "statement" {
+    for_each = local.inplace_reader_accounts
 
-    principals {
-      type        = "AWS"
-      identifiers = [local.inplace_cxm_principal]
+    content {
+      sid       = "CxMInPlaceGetObject${statement.value}"
+      actions   = ["s3:GetObject"]
+      resources = ["${local.inplace_bucket_arn}/${local.inplace_object_prefix}*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
     }
   }
 
-  statement {
-    sid       = "CxMInPlaceListBucket"
-    actions   = ["s3:ListBucket"]
-    resources = [local.inplace_bucket_arn]
+  dynamic "statement" {
+    for_each = local.inplace_reader_accounts
 
-    principals {
-      type        = "AWS"
-      identifiers = [local.inplace_cxm_principal]
-    }
+    content {
+      sid       = "CxMInPlaceListBucket${statement.value}"
+      actions   = ["s3:ListBucket"]
+      resources = [local.inplace_bucket_arn]
 
-    condition {
-      test     = "StringLike"
-      variable = "s3:prefix"
-      values   = ["${local.inplace_object_prefix}*"]
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values   = ["${local.inplace_object_prefix}*"]
+      }
     }
   }
 
-  statement {
-    sid       = "CxMInPlaceGetBucketLocation"
-    actions   = ["s3:GetBucketLocation"]
-    resources = [local.inplace_bucket_arn]
+  dynamic "statement" {
+    for_each = local.inplace_reader_accounts
 
-    principals {
-      type        = "AWS"
-      identifiers = [local.inplace_cxm_principal]
+    content {
+      sid       = "CxMInPlaceGetBucketLocation${statement.value}"
+      actions   = ["s3:GetBucketLocation"]
+      resources = [local.inplace_bucket_arn]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
     }
   }
 }
@@ -69,14 +91,18 @@ data "aws_iam_policy_document" "cxm_inplace_kms_statement" {
   count   = local.inplace_kms_statement ? 1 : 0
   version = "2012-10-17"
 
-  statement {
-    sid       = "CxMInPlaceDecrypt"
-    actions   = ["kms:Decrypt", "kms:DescribeKey"]
-    resources = ["*"]
+  dynamic "statement" {
+    for_each = local.inplace_reader_accounts
 
-    principals {
-      type        = "AWS"
-      identifiers = [local.inplace_cxm_principal]
+    content {
+      sid       = "CxMInPlaceDecrypt${statement.value}"
+      actions   = ["kms:Decrypt", "kms:DescribeKey"]
+      resources = ["*"]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
     }
   }
 }
@@ -89,14 +115,17 @@ data "aws_s3_bucket_policy" "existing" {
   bucket = var.s3_bucket_name
 }
 
+# Our statements go in override_policy_documents, not source: the second apply reads back a
+# policy that already carries them, and source_policy_documents rejects a duplicate Sid
+# outright ("duplicate Sid ... Remove the Sid or ensure Sids are unique"). override replaces
+# a same-Sid statement instead, so re-applying is idempotent and anything else in the policy
+# still survives.
 data "aws_iam_policy_document" "cxm_inplace_bucket_policy" {
   count   = var.manage_bucket_policy ? 1 : 0
   version = "2012-10-17"
 
-  source_policy_documents = concat(
-    [for existing in data.aws_s3_bucket_policy.existing : existing.policy],
-    [data.aws_iam_policy_document.cxm_inplace_bucket_statements.json],
-  )
+  source_policy_documents   = [for existing in data.aws_s3_bucket_policy.existing : existing.policy]
+  override_policy_documents = [data.aws_iam_policy_document.cxm_inplace_bucket_statements.json]
 }
 
 resource "aws_s3_bucket_policy" "cxm_inplace" {
@@ -112,10 +141,8 @@ data "aws_iam_policy_document" "cxm_inplace_kms_key_policy" {
   count   = var.manage_kms_key_policy ? 1 : 0
   version = "2012-10-17"
 
-  source_policy_documents = [
-    var.existing_kms_key_policy_json,
-    data.aws_iam_policy_document.cxm_inplace_kms_statement[0].json,
-  ]
+  source_policy_documents   = [var.existing_kms_key_policy_json]
+  override_policy_documents = [data.aws_iam_policy_document.cxm_inplace_kms_statement[0].json]
 }
 
 resource "aws_kms_key_policy" "cxm_inplace" {

--- a/terraform-aws-s3-bucket-read/inplace-query-access.tf
+++ b/terraform-aws-s3-bucket-read/inplace-query-access.tf
@@ -1,34 +1,21 @@
-# In-place query access (resource policy).
-#
-# Athena reads S3 as the principal that submitted the query and cannot be handed an
-# assumed-role session, so the identity policy in main.tf never applies to the scan path.
-# A resource policy on the bucket (and on the KMS key, when the bucket is encrypted) is
-# the only grant that works. The principal is account-delegated and narrowed by object
-# prefix, never by role name: submitting roles are named per tenant and per service, so
-# naming them would break the policy on any rename.
+# Athena reads S3 as the query submitter, not the assumed role, so only a resource policy
+# works. Principal is the account, narrowed by prefix: role names change, accounts do not.
 
 locals {
   inplace_object_prefix = "${trimsuffix(var.inplace_query_object_prefix, "/")}/"
   inplace_bucket_arn    = "arn:aws:s3:::${var.s3_bucket_name}"
   inplace_kms_statement = var.s3_bucket_kms_key_arn != null || var.manage_kms_key_policy
 
-  # One statement per reader account, with the account id in the Sid. A bucket read by
-  # several CXM tenants gets one statement set each. The suffix is what makes them mergeable:
-  # aws_iam_policy_document rejects a duplicate Sid outright ("Remove the Sid or ensure Sids
-  # are unique"), and while PutBucketPolicy does accept duplicates, two statements sharing a
-  # Sid cannot be told apart afterwards — so one reader's grant could not be updated or
-  # revoked without touching the other's.
+  # Account id in the Sid: aws_iam_policy_document rejects duplicate Sids, and S3 accepts them
+  # but then one reader's grant cannot be revoked without rewriting the other's.
   inplace_reader_accounts = distinct(concat(
     [var.cxm_aws_account_id],
     [for reader in var.additional_cxm_readers : reader.account_id],
   ))
 }
 
-# Three separate statements are mandatory: s3:GetBucketLocation does not support the
-# s3:prefix condition key, so folding it in with s3:ListBucket is rejected as
-# MalformedPolicy — and a rejected PutBucketPolicy leaves the previous policy live.
-# Do NOT add an aws:CalledVia condition here: Athena does not populate CalledVia on its
-# scan requests, so the condition denies Athena itself.
+# Keep the three statements split: GetBucketLocation rejects the s3:prefix condition key.
+# No aws:CalledVia — Athena does not set it on scans, so the condition would deny Athena.
 data "aws_iam_policy_document" "cxm_inplace_bucket_statements" {
   version = "2012-10-17"
 
@@ -84,9 +71,8 @@ data "aws_iam_policy_document" "cxm_inplace_bucket_statements" {
   }
 }
 
-# The identity-policy kms:Decrypt in main.tf does not substitute for a key policy: the
-# query submitter is not the role that identity policy is attached to.
-# kms:GenerateDataKey is write-side only and deliberately excluded.
+# The reader role's kms:Decrypt does not cover the query submitter. GenerateDataKey is
+# write-side only, so it stays out.
 data "aws_iam_policy_document" "cxm_inplace_kms_statement" {
   count   = local.inplace_kms_statement ? 1 : 0
   version = "2012-10-17"
@@ -107,19 +93,15 @@ data "aws_iam_policy_document" "cxm_inplace_kms_statement" {
   }
 }
 
-# Opt-in ownership of the bucket policy. Only ever safe on a bucket dedicated to this
-# integration: aws_s3_bucket_policy replaces the whole policy, and log buckets always
-# carry AWS log-delivery statements that must survive.
+# Opt-in only: aws_s3_bucket_policy replaces the whole policy, and log buckets carry
+# AWS log-delivery statements that must survive.
 data "aws_s3_bucket_policy" "existing" {
   count  = var.manage_bucket_policy && var.merge_existing_bucket_policy ? 1 : 0
   bucket = var.s3_bucket_name
 }
 
-# Our statements go in override_policy_documents, not source: the second apply reads back a
-# policy that already carries them, and source_policy_documents rejects a duplicate Sid
-# outright ("duplicate Sid ... Remove the Sid or ensure Sids are unique"). override replaces
-# a same-Sid statement instead, so re-applying is idempotent and anything else in the policy
-# still survives.
+# Ours go in override, not source: the second apply reads back a policy already carrying them
+# and source rejects the duplicate Sid. override replaces it instead, so re-applying works.
 data "aws_iam_policy_document" "cxm_inplace_bucket_policy" {
   count   = var.manage_bucket_policy ? 1 : 0
   version = "2012-10-17"
@@ -134,9 +116,8 @@ resource "aws_s3_bucket_policy" "cxm_inplace" {
   policy = data.aws_iam_policy_document.cxm_inplace_bucket_policy[count.index].json
 }
 
-# The AWS provider exposes no data source for an existing KMS key policy, so the current
-# policy must be handed in explicitly. Replacing a key policy without its administrative
-# statements locks the key permanently, hence the precondition rather than a silent default.
+# No data source exists for a key policy, so it is handed in. Replacing one without its
+# admin statements locks the key for good — hence the precondition.
 data "aws_iam_policy_document" "cxm_inplace_kms_key_policy" {
   count   = var.manage_kms_key_policy ? 1 : 0
   version = "2012-10-17"

--- a/terraform-aws-s3-bucket-read/main.tf
+++ b/terraform-aws-s3-bucket-read/main.tf
@@ -21,6 +21,7 @@ module "cxm_cfg_iam_role" {
   permission_boundary_arn = var.permission_boundary_arn
   cxm_aws_account_id      = var.cxm_aws_account_id
   cxm_role_name           = var.cxm_role_name
+  additional_cxm_readers  = var.additional_cxm_readers
   tags                    = var.tags
 }
 

--- a/terraform-aws-s3-bucket-read/variables.tf
+++ b/terraform-aws-s3-bucket-read/variables.tf
@@ -104,3 +104,12 @@ variable "tags" {
   description = "A map/dictionary of Tags to be assigned to created resources"
   default     = {}
 }
+
+variable "additional_cxm_readers" {
+  type = list(object({
+    account_id  = string
+    external_id = string
+  }))
+  default     = []
+  description = "Extra Cloud ex Machina accounts that read this bucket, each with its own external ID. Adds a trust statement on the reader role and an in-place query statement set on the bucket (and key) per entry, so several CXM tenants can share one bucket."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -120,3 +120,12 @@ variable "tags" {
   description = "A map/dictionary of Tags to be assigned to created resources"
   default     = {}
 }
+
+variable "additional_cxm_readers" {
+  type = list(object({
+    account_id  = string
+    external_id = string
+  }))
+  default     = []
+  description = "Extra Cloud ex Machina accounts that read the CUR, CloudTrail and Flow Logs buckets, each with its own external ID. Provided by CXM when more than one CXM tenant analyses the same buckets: each entry adds a trust statement on the reader roles and an in-place query statement set on the buckets."
+}


### PR DESCRIPTION
## Why

`cxm-flow-logs-storage` is read by two CXM environments — cava and production. The module could only ever express one, because the reader role carries a single trust statement with a single external ID and the in-place grant hardcodes one principal under a fixed `Sid`.

What that cost us in practice: applying `internal/production-enablement` collided with the existing `cxm-flowlogs-reader` (canonical name, so no suffix to distinguish it), and the only way through was to take the role over and rewrite cava's trust away. One environment gains access by removing the other's.

## What changes

**`additional_cxm_readers`** — `list(object({ account_id, external_id }))`, default `[]`, on the root module and both submodules. Non-breaking: existing callers are untouched.

- One trust statement per reader. Not one statement with several external IDs: `StringEquals` with several values is an OR, which would let any reader in with any ID.
- One in-place statement set per reader on the bucket and the key.
- Additional readers are account-delegated (`:root`); `cxm_role_name` still narrows the primary reader.

**Account id in every in-place `Sid`.** S3 *does* accept two statements sharing a `Sid` — I checked — but nothing can tell them apart afterwards, so revoking one reader would mean rewriting the other's grant. And `aws_iam_policy_document` rejects a duplicate `Sid` outright:

```
Error: merging source document 1: duplicate Sid (CxMInPlaceGetObject) in
source_policy_documents (statement 0). Remove the Sid or ensure Sids are unique.
```

**`manage_bucket_policy = true` was a one-shot** — a latent bug this uncovered. The second apply reads back a policy that already carries our statements and merges them into themselves, hitting exactly the error above. Our statements move from `source_policy_documents` to `override_policy_documents`, which replaces a same-`Sid` statement rather than erroring, so re-applying is idempotent and anything else in the policy still survives. Same fix on the KMS key policy.

## Verification

Real AWS, not reasoning:

- Plan with two readers → two trust statements with distinct external IDs, six bucket statements with unique `Sid`s.
- `put-bucket-policy` with those six statements on a throwaway sandbox bucket → accepted, 6 statements live. Bucket deleted.
- Duplicate-`Sid` and `override_policy_documents` semantics both measured with a scratch config rather than assumed.
- `terraform fmt` clean; `tflint --recursive` reports the same 15 pre-existing warnings before and after.

## Migration

The `Sid` change means a policy carrying the old un-suffixed statements keeps them: they are not replaced, and they grant the same access. Adopters should drop the un-suffixed `CxMInPlace*` statements when they next edit the policy. Nothing is broken in the meantime, and no customer has adopted the in-place grant yet — `cxm-flow-logs-storage` carries hand-written statements that this PR lets us replace with module-generated ones.

Submodule README table separators are reformatted by the `terraform_docs` pre-commit hook, not by hand.

## Follow-up (not in this PR)

`internal/production-enablement` and `customer-accounts/cava` in cloud-infra should declare each other as `additional_cxm_readers` on the flow-logs bucket, so cava's trust comes back and the shared bucket ends up with one module-owned grant. That needs this merged first — cloud-infra sources the module from a sibling checkout.

Paired with cxmlabs/cloudformation-aws-cxm-integration#24, which does the same for the CloudFormation route so both keep producing identical policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)