### PR TITLE
feat(s3-bucket-read): CloudTrail in-place query — bucket-policy merge + KMS grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,7 @@ provider "aws" {
 | deployment_targets | Add a filter, and list of Organizational Units from the Organization to only deploy to. If left blank, all organization will be crawled by default. | `set(any)` | `[]` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | s3_kms_key_arn | Optional - ARN of the KMS Key that is used to encrypt CUR data | `string` | `null` | no |
-| cloudtrail_manage_bucket_policy | Let Terraform own the CloudTrail bucket policy and merge the in-place query statements into it. Leave `false` to take the statements from the outputs and merge them yourself. | `bool` | `false` | no |
-| cloudtrail_manage_kms_key_policy | Let Terraform own the CloudTrail KMS key policy and merge the in-place decrypt statement into it. Requires s3_kms_key_arn and cloudtrail_existing_kms_key_policy_json. Applied in the aws.root (management) account, where the Control Tower CloudTrail key lives. | `bool` | `false` | no |
-| cloudtrail_existing_kms_key_policy_json | Current policy of the CloudTrail KMS key, merged with the CXM decrypt statement. Required when cloudtrail_manage_kms_key_policy is `true`: AWS exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable. | `string` | `null` | no |
+| cloudtrail_enable_inplace_query | Grant the CXM reader accounts in-place Athena query access to the CloudTrail bucket: merges the read statements into the live bucket policy and adds a KMS grant for s3_kms_key_arn (in the aws.root management account, where the Control Tower CloudTrail key lives). Nothing in the existing bucket or key policy is re-declared. | `bool` | `false` | no |
 | cloudtrail_inplace_query_object_prefix | Object key prefix the CloudTrail in-place query grant is narrowed to (e.g. `o-xxxx/AWSLogs/o-xxxx/` for an organization trail). | `string` | `"AWSLogs"` | no |
 | flowlogs_bucket_name | Name of the S3 bucket storing centralized VPC Flow Logs. Required when disable_flowlogs_analysis is false. | `string` | `null` | no |
 | flowlogs_kms_key_arn | Optional - ARN of the KMS key used to encrypt VPC Flow Logs data in S3. | `string` | `null` | no |
@@ -281,7 +279,6 @@ provider "aws" {
 | flowlogs_region | AWS region used for the VPC Flow Logs deployment (must match the Flow Logs S3 bucket region) |
 | flowlogs_iam_role_arn | ARN of the CXM IAM role for VPC Flow Logs reading |
 | inplace_query_bucket_policy_statements | Bucket policy statements to merge into each log bucket's existing policy so CXM can query it in place, keyed by data source. |
-| inplace_query_kms_key_policy_statements | KMS key policy statements to merge into each log bucket's encryption key policy, keyed by data source. Empty when no customer managed key is configured. |
 | stackset_deployment_region | AWS region where StackSet instances deploy IAM roles in member accounts (hardcoded to us-east-1) |
 | discovered_account_ids | Active sub-account IDs discovered from the organization. Use these to set up the terraform-aws-sub-account-cxm-enablement module. |
 | prefix | Prefix used for all resource names across modules. |

--- a/README.md
+++ b/README.md
@@ -194,23 +194,23 @@ provider "aws" {
 ### Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | terraform | >= 1.5.0 |
 | aws | >= 5.0 |
 
 ### Providers
 
 | Name | Version |
-| ---- | ------- |
-| aws.root | 6.58.0 |
-| aws.cur | 6.58.0 |
-| aws.cloudtrail | 6.58.0 |
-| aws.flowlogs | 6.58.0 |
+|------|---------|
+| aws.root | 6.62.0 |
+| aws.cur | 6.62.0 |
+| aws.cloudtrail | 6.62.0 |
+| aws.flowlogs | 6.62.0 |
 
 ### Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | enable_root_organization | ./terraform-aws-organization-enablement | n/a |
 | enable_sub_accounts | ./terraform-aws-full-organization-enablement | n/a |
 | enable_lone_account | ./terraform-aws-account-enablement | n/a |
@@ -221,7 +221,7 @@ provider "aws" {
 ### Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_caller_identity.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.cur](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.flowlogs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -235,7 +235,7 @@ provider "aws" {
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | cxm_aws_account_id | The Cloud ex Machina AWS account that the IAM role will grant access to. Provided by CXM. | `string` | n/a | yes |
 | cxm_external_id | External ID to use in the trust relationship. Provided by CXM. | `string` | n/a | yes |
 | cost_usage_report_bucket_name | Name of the bucket that is used to store CUR data. Required when disable_cur_analysis is false (the default). | `string` | `null` | no |
@@ -251,6 +251,10 @@ provider "aws" {
 | deployment_targets | Add a filter, and list of Organizational Units from the Organization to only deploy to. If left blank, all organization will be crawled by default. | `set(any)` | `[]` | no |
 | permission_boundary_arn | Optional - ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
 | s3_kms_key_arn | Optional - ARN of the KMS Key that is used to encrypt CUR data | `string` | `null` | no |
+| cloudtrail_manage_bucket_policy | Let Terraform own the CloudTrail bucket policy and merge the in-place query statements into it. Leave `false` to take the statements from the outputs and merge them yourself. | `bool` | `false` | no |
+| cloudtrail_manage_kms_key_policy | Let Terraform own the CloudTrail KMS key policy and merge the in-place decrypt statement into it. Requires s3_kms_key_arn and cloudtrail_existing_kms_key_policy_json. Applied in the aws.root (management) account, where the Control Tower CloudTrail key lives. | `bool` | `false` | no |
+| cloudtrail_existing_kms_key_policy_json | Current policy of the CloudTrail KMS key, merged with the CXM decrypt statement. Required when cloudtrail_manage_kms_key_policy is `true`: AWS exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable. | `string` | `null` | no |
+| cloudtrail_inplace_query_object_prefix | Object key prefix the CloudTrail in-place query grant is narrowed to (e.g. `o-xxxx/AWSLogs/o-xxxx/` for an organization trail). | `string` | `"AWSLogs"` | no |
 | flowlogs_bucket_name | Name of the S3 bucket storing centralized VPC Flow Logs. Required when disable_flowlogs_analysis is false. | `string` | `null` | no |
 | flowlogs_kms_key_arn | Optional - ARN of the KMS key used to encrypt VPC Flow Logs data in S3. | `string` | `null` | no |
 | prefix | Optional - prefix for key constructs created by this module. | `string` | `"cxm"` | no |
@@ -261,7 +265,7 @@ provider "aws" {
 ### Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | lone_account_iam_role_arn | ARN of the CXM IAM role for lone account deployment |
 | organization_iam_role_arn | ARN of the CXM IAM role for organization root deployment |
 | cxm_iam_role_name | Name of the CXM IAM role deployed in the root account (organization crawler, or the lone-account role). NOT the role to use for EKS cluster enablement in an Organization deployment - see cxm_eks_iam_role_name. |

--- a/main.tf
+++ b/main.tf
@@ -105,10 +105,9 @@ module "enable_cloudtrail" {
   s3_bucket_name         = var.cloudtrail_bucket_name
   s3_bucket_kms_key_arn  = var.s3_kms_key_arn
 
-  inplace_query_object_prefix  = var.cloudtrail_inplace_query_object_prefix
-  manage_bucket_policy         = var.cloudtrail_manage_bucket_policy
-  manage_kms_key_policy        = var.cloudtrail_manage_kms_key_policy
-  existing_kms_key_policy_json = var.cloudtrail_existing_kms_key_policy_json
+  inplace_query_object_prefix = var.cloudtrail_inplace_query_object_prefix
+  manage_bucket_policy        = var.cloudtrail_enable_inplace_query
+  manage_kms_grant            = var.cloudtrail_enable_inplace_query
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,8 @@ module "enable_cur" {
   count = local.enable_cur ? 1 : 0
 
   providers = {
-    aws = aws.cur
+    aws     = aws.cur
+    aws.kms = aws.cur
   }
 
   iam_role_external_id = var.cxm_external_id
@@ -90,6 +91,9 @@ module "enable_cloudtrail" {
 
   providers = {
     aws = aws.cloudtrail
+    # CloudTrail's KMS key lives in the organization management account, not the log-archive
+    # account that holds the bucket.
+    aws.kms = aws.root
   }
 
   iam_role_external_id = var.cxm_external_id
@@ -100,7 +104,13 @@ module "enable_cloudtrail" {
   additional_cxm_readers = var.additional_cxm_readers
   s3_bucket_name         = var.cloudtrail_bucket_name
   s3_bucket_kms_key_arn  = var.s3_kms_key_arn
-  tags                   = local.tags
+
+  inplace_query_object_prefix  = var.cloudtrail_inplace_query_object_prefix
+  manage_bucket_policy         = var.cloudtrail_manage_bucket_policy
+  manage_kms_key_policy        = var.cloudtrail_manage_kms_key_policy
+  existing_kms_key_policy_json = var.cloudtrail_existing_kms_key_policy_json
+
+  tags = local.tags
 }
 
 # VPC FLOW LOGS
@@ -110,7 +120,8 @@ module "enable_flowlogs" {
   count = local.enable_flowlogs ? 1 : 0
 
   providers = {
-    aws = aws.flowlogs
+    aws     = aws.flowlogs
+    aws.kms = aws.flowlogs
   }
 
   iam_role_external_id = var.cxm_external_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -96,16 +96,6 @@ output "inplace_query_bucket_policy_statements" {
   description = "Bucket policy statements to merge into each log bucket's existing policy so CXM can query it in place, keyed by data source."
 }
 
-output "inplace_query_kms_key_policy_statements" {
-  value = {
-    for source, statement in merge(
-      local.enable_cloudtrail ? { cloudtrail = module.enable_cloudtrail[0].inplace_query_kms_key_policy_statement_json } : {},
-      local.enable_flowlogs ? { flowlogs = module.enable_flowlogs[0].inplace_query_kms_key_policy_statement_json } : {},
-    ) : source => statement if statement != null
-  }
-  description = "KMS key policy statements to merge into each log bucket's encryption key policy, keyed by data source. Empty when no customer managed key is configured."
-}
-
 output "stackset_deployment_region" {
   value       = local.enable_root_org_discovery ? "us-east-1" : null
   description = "AWS region where StackSet instances deploy IAM roles in member accounts (hardcoded to us-east-1)"

--- a/terraform-aws-s3-bucket-read/README.md
+++ b/terraform-aws-s3-bucket-read/README.md
@@ -41,7 +41,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | [aws_iam_role.cxm_feedback_loop_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cxm_cross_account_eventbridge_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cxm_s3_ro_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_key_policy.cxm_inplace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
+| [aws_kms_grant.cxm_inplace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_policy.cxm_inplace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
@@ -49,8 +49,6 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | [aws_iam_policy_document.cxm_cross_account_eventbridge_put_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cxm_inplace_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cxm_inplace_bucket_statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cxm_inplace_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cxm_inplace_kms_statement](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cxm_s3_ro_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_s3_bucket_policy.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_policy) | data source |
@@ -74,8 +72,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | inplace_query_object_prefix | Object key prefix the in-place query grant is narrowed to. A trailing `/` is added automatically. | `string` | `"AWSLogs"` | no |
 | manage_bucket_policy | Set to `true` only for a bucket dedicated to this integration. Terraform then owns the bucket policy. Leave `false` for CloudTrail and VPC Flow Logs buckets: they carry AWS log-delivery statements, and taking ownership risks breaking log delivery. In the default mode the required statements are exposed as outputs for you to merge into your own policy. | `bool` | `false` | no |
 | merge_existing_bucket_policy | When manage_bucket_policy is `true`, read the bucket's current policy and merge into it instead of replacing it. Set to `false` only for a bucket that has no policy at all — the read fails otherwise. | `bool` | `true` | no |
-| manage_kms_key_policy | Set to `true` to let Terraform own the KMS key policy of s3_bucket_kms_key_arn. Requires existing_kms_key_policy_json. Leave `false` to take the statement from the outputs instead. | `bool` | `false` | no |
-| existing_kms_key_policy_json | Current policy of s3_bucket_kms_key_arn, merged with the CXM decrypt statement. Required when manage_kms_key_policy is `true`: the AWS provider exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable. | `string` | `null` | no |
+| manage_kms_grant | Set to `true` to grant each reader account kms:Decrypt on s3_bucket_kms_key_arn via a KMS grant. Additive: it never reads or replaces the key policy, so the key's existing statements (e.g. Control Tower's) are left untouched. No effect when s3_bucket_kms_key_arn is null. | `bool` | `false` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
 | additional_cxm_readers | Extra Cloud ex Machina accounts that read this bucket, each with its own external ID. Adds a trust statement on the reader role and an in-place query statement set on the bucket (and key) per entry, so several CXM tenants can share one bucket. | ```list(object({ account_id = string external_id = string }))``` | `[]` | no |
 
@@ -90,6 +87,5 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 | prefix | Prefix used for all resource names. |
 | cxm_aws_account_id | CXM AWS account ID trusted by the IAM role. |
 | inplace_query_bucket_policy_statements_json | Bucket policy statements granting CXM in-place query access. Merge these into the bucket's existing policy when manage_bucket_policy is `false`. |
-| inplace_query_kms_key_policy_statement_json | KMS key policy statement granting CXM decrypt access. Merge this into the key's existing policy when manage_kms_key_policy is `false`. Null when the bucket is not encrypted with a customer managed key. |
 | inplace_query_object_prefix | Object key prefix the in-place query grant is narrowed to. |
 <!-- END_TF_DOCS -->

--- a/terraform-aws-s3-bucket-read/README.md
+++ b/terraform-aws-s3-bucket-read/README.md
@@ -11,7 +11,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 ### Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | terraform | >= 1.5.0 |
 | aws | >= 3.74.0 |
 | random | >= 2.1 |
@@ -19,20 +19,21 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 ### Providers
 
 | Name | Version |
-| ---- | ------- |
-| random | >= 2.1 |
-| aws | >= 3.74.0 |
+|------|---------|
+| aws.kms | 6.62.0 |
+| random | 3.9.0 |
+| aws | 6.62.0 |
 
 ### Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | cxm_cfg_iam_role | ../terraform-aws-iam-role | n/a |
 
 ### Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_cloudwatch_event_rule.cxm_bucket_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.cxm_data_plane_bus](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.cxm_cross_account_eventbridge_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -57,7 +58,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | use_existing_iam_role | Set this to true to use an existing IAM role | `bool` | `false` | no |
 | use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role, rather than attaching a new one | `bool` | `false` | no |
 | iam_role_arn | The IAM role ARN is required when setting use_existing_iam_role to `true` | `string` | `null` | no |
@@ -81,7 +82,7 @@ This module enables CXM roles to read *Cost and Usage Report* (CUR) bucket, and 
 ### Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | external_id | The External ID configured into the IAM role |
 | iam_role_name | The IAM Role name |
 | iam_role_arn | The IAM Role ARN |

--- a/terraform-aws-s3-bucket-read/inplace-query-access.tf
+++ b/terraform-aws-s3-bucket-read/inplace-query-access.tf
@@ -4,7 +4,6 @@
 locals {
   inplace_object_prefix = "${trimsuffix(var.inplace_query_object_prefix, "/")}/"
   inplace_bucket_arn    = "arn:aws:s3:::${var.s3_bucket_name}"
-  inplace_kms_statement = var.s3_bucket_kms_key_arn != null || var.manage_kms_key_policy
 
   # Account id in the Sid: aws_iam_policy_document rejects duplicate Sids, and S3 accepts them
   # but then one reader's grant cannot be revoked without rewriting the other's.
@@ -71,28 +70,6 @@ data "aws_iam_policy_document" "cxm_inplace_bucket_statements" {
   }
 }
 
-# The reader role's kms:Decrypt does not cover the query submitter. GenerateDataKey is
-# write-side only, so it stays out.
-data "aws_iam_policy_document" "cxm_inplace_kms_statement" {
-  count   = local.inplace_kms_statement ? 1 : 0
-  version = "2012-10-17"
-
-  dynamic "statement" {
-    for_each = local.inplace_reader_accounts
-
-    content {
-      sid       = "CxMInPlaceDecrypt${statement.value}"
-      actions   = ["kms:Decrypt", "kms:DescribeKey"]
-      resources = ["*"]
-
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-      }
-    }
-  }
-}
-
 # Opt-in only: aws_s3_bucket_policy replaces the whole policy, and log buckets carry
 # AWS log-delivery statements that must survive.
 data "aws_s3_bucket_policy" "existing" {
@@ -116,26 +93,15 @@ resource "aws_s3_bucket_policy" "cxm_inplace" {
   policy = data.aws_iam_policy_document.cxm_inplace_bucket_policy[count.index].json
 }
 
-# No data source exists for a key policy, so it is handed in. Replacing one without its
-# admin statements locks the key for good — hence the precondition.
-data "aws_iam_policy_document" "cxm_inplace_kms_key_policy" {
-  count   = var.manage_kms_key_policy ? 1 : 0
-  version = "2012-10-17"
+# A grant is additive: it gives each reader account Decrypt without reading or replacing the
+# key policy, so the key's existing statements are left untouched. GenerateDataKey is
+# write-side only, so it stays out. The reading account's own IAM narrows the actual use.
+resource "aws_kms_grant" "cxm_inplace" {
+  for_each = var.manage_kms_grant && var.s3_bucket_kms_key_arn != null ? toset(local.inplace_reader_accounts) : toset([])
 
-  source_policy_documents   = [var.existing_kms_key_policy_json]
-  override_policy_documents = [data.aws_iam_policy_document.cxm_inplace_kms_statement[0].json]
-}
-
-resource "aws_kms_key_policy" "cxm_inplace" {
-  provider = aws.kms
-  count    = var.manage_kms_key_policy ? 1 : 0
-  key_id   = var.s3_bucket_kms_key_arn
-  policy   = data.aws_iam_policy_document.cxm_inplace_kms_key_policy[count.index].json
-
-  lifecycle {
-    precondition {
-      condition     = var.s3_bucket_kms_key_arn != null && var.existing_kms_key_policy_json != null
-      error_message = "manage_kms_key_policy requires both s3_bucket_kms_key_arn and existing_kms_key_policy_json: the current key policy must be merged in, or the key becomes unmanageable."
-    }
-  }
+  provider          = aws.kms
+  name              = "cxm-inplace-decrypt-${each.value}"
+  key_id            = var.s3_bucket_kms_key_arn
+  grantee_principal = "arn:aws:iam::${each.value}:root"
+  operations        = ["Decrypt", "DescribeKey"]
 }

--- a/terraform-aws-s3-bucket-read/inplace-query-access.tf
+++ b/terraform-aws-s3-bucket-read/inplace-query-access.tf
@@ -127,9 +127,10 @@ data "aws_iam_policy_document" "cxm_inplace_kms_key_policy" {
 }
 
 resource "aws_kms_key_policy" "cxm_inplace" {
-  count  = var.manage_kms_key_policy ? 1 : 0
-  key_id = var.s3_bucket_kms_key_arn
-  policy = data.aws_iam_policy_document.cxm_inplace_kms_key_policy[count.index].json
+  provider = aws.kms
+  count    = var.manage_kms_key_policy ? 1 : 0
+  key_id   = var.s3_bucket_kms_key_arn
+  policy   = data.aws_iam_policy_document.cxm_inplace_kms_key_policy[count.index].json
 
   lifecycle {
     precondition {

--- a/terraform-aws-s3-bucket-read/outputs.tf
+++ b/terraform-aws-s3-bucket-read/outputs.tf
@@ -33,11 +33,6 @@ output "inplace_query_bucket_policy_statements_json" {
   description = "Bucket policy statements granting CXM in-place query access. Merge these into the bucket's existing policy when manage_bucket_policy is `false`."
 }
 
-output "inplace_query_kms_key_policy_statement_json" {
-  value       = one(data.aws_iam_policy_document.cxm_inplace_kms_statement[*].json)
-  description = "KMS key policy statement granting CXM decrypt access. Merge this into the key's existing policy when manage_kms_key_policy is `false`. Null when the bucket is not encrypted with a customer managed key."
-}
-
 output "inplace_query_object_prefix" {
   value       = local.inplace_object_prefix
   description = "Object key prefix the in-place query grant is narrowed to."

--- a/terraform-aws-s3-bucket-read/variables.tf
+++ b/terraform-aws-s3-bucket-read/variables.tf
@@ -87,16 +87,10 @@ variable "merge_existing_bucket_policy" {
   description = "When manage_bucket_policy is `true`, read the bucket's current policy and merge into it instead of replacing it. Set to `false` only for a bucket that has no policy at all — the read fails otherwise."
 }
 
-variable "manage_kms_key_policy" {
+variable "manage_kms_grant" {
   type        = bool
   default     = false
-  description = "Set to `true` to let Terraform own the KMS key policy of s3_bucket_kms_key_arn. Requires existing_kms_key_policy_json. Leave `false` to take the statement from the outputs instead."
-}
-
-variable "existing_kms_key_policy_json" {
-  type        = string
-  default     = null
-  description = "Current policy of s3_bucket_kms_key_arn, merged with the CXM decrypt statement. Required when manage_kms_key_policy is `true`: the AWS provider exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable."
+  description = "Set to `true` to grant each reader account kms:Decrypt on s3_bucket_kms_key_arn via a KMS grant. Additive: it never reads or replaces the key policy, so the key's existing statements (e.g. Control Tower's) are left untouched. No effect when s3_bucket_kms_key_arn is null."
 }
 
 variable "tags" {

--- a/terraform-aws-s3-bucket-read/versions.tf
+++ b/terraform-aws-s3-bucket-read/versions.tf
@@ -5,6 +5,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 3.74.0"
+      # aws.kms owns the in-place KMS key policy, which for a log bucket lives in a different
+      # account than the bucket. Map it to the bucket's provider where they share an account.
+      configuration_aliases = [aws.kms]
     }
     random = {
       source  = "hashicorp/random"

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,30 @@ variable "s3_kms_key_arn" {
   description = "Optional - ARN of the KMS Key that is used to encrypt CUR data"
 }
 
+variable "cloudtrail_manage_bucket_policy" {
+  type        = bool
+  default     = false
+  description = "Let Terraform own the CloudTrail bucket policy and merge the in-place query statements into it. Leave `false` to take the statements from the outputs and merge them yourself."
+}
+
+variable "cloudtrail_manage_kms_key_policy" {
+  type        = bool
+  default     = false
+  description = "Let Terraform own the CloudTrail KMS key policy and merge the in-place decrypt statement into it. Requires s3_kms_key_arn and cloudtrail_existing_kms_key_policy_json. Applied in the aws.root (management) account, where the Control Tower CloudTrail key lives."
+}
+
+variable "cloudtrail_existing_kms_key_policy_json" {
+  type        = string
+  default     = null
+  description = "Current policy of the CloudTrail KMS key, merged with the CXM decrypt statement. Required when cloudtrail_manage_kms_key_policy is `true`: AWS exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable."
+}
+
+variable "cloudtrail_inplace_query_object_prefix" {
+  type        = string
+  default     = "AWSLogs"
+  description = "Object key prefix the CloudTrail in-place query grant is narrowed to (e.g. `o-xxxx/AWSLogs/o-xxxx/` for an organization trail)."
+}
+
 variable "flowlogs_bucket_name" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -91,22 +91,10 @@ variable "s3_kms_key_arn" {
   description = "Optional - ARN of the KMS Key that is used to encrypt CUR data"
 }
 
-variable "cloudtrail_manage_bucket_policy" {
+variable "cloudtrail_enable_inplace_query" {
   type        = bool
   default     = false
-  description = "Let Terraform own the CloudTrail bucket policy and merge the in-place query statements into it. Leave `false` to take the statements from the outputs and merge them yourself."
-}
-
-variable "cloudtrail_manage_kms_key_policy" {
-  type        = bool
-  default     = false
-  description = "Let Terraform own the CloudTrail KMS key policy and merge the in-place decrypt statement into it. Requires s3_kms_key_arn and cloudtrail_existing_kms_key_policy_json. Applied in the aws.root (management) account, where the Control Tower CloudTrail key lives."
-}
-
-variable "cloudtrail_existing_kms_key_policy_json" {
-  type        = string
-  default     = null
-  description = "Current policy of the CloudTrail KMS key, merged with the CXM decrypt statement. Required when cloudtrail_manage_kms_key_policy is `true`: AWS exposes no data source for a key policy, and replacing one without its administrative statements makes the key unmanageable."
+  description = "Grant the CXM reader accounts in-place Athena query access to the CloudTrail bucket: merges the read statements into the live bucket policy and adds a KMS grant for s3_kms_key_arn (in the aws.root management account, where the Control Tower CloudTrail key lives). Nothing in the existing bucket or key policy is re-declared."
 }
 
 variable "cloudtrail_inplace_query_object_prefix" {


### PR DESCRIPTION
## What this does

Lets a caller grant CXM reader accounts in-place Athena query access to a Control Tower CloudTrail bucket through the module alone — no hand-written side file, and nothing the customer already has (bucket policy, key policy) is re-declared.

## Interface

One meaningful flag on the root module:

```hcl
module "cxm_integration" {
  providers = {
    aws.root       = aws.organizations # holds the CloudTrail KMS key
    aws.cloudtrail = aws.cloudtrail    # holds the CloudTrail bucket
    # ...
  }

  cloudtrail_bucket_name                 = "aws-controltower-logs-…"
  s3_kms_key_arn                         = "arn:aws:kms:…"            # the key that encrypts it
  additional_cxm_readers                 = [{ account_id = "…", external_id = "…" }]

  cloudtrail_enable_inplace_query        = true
  cloudtrail_inplace_query_object_prefix = "o-xxxx/AWSLogs/o-xxxx/"
}
```

## How it works

- **Bucket policy**: read the live policy (`aws_s3_bucket_policy` data source) and merge the CXM read statements in via `override_policy_documents`. Control Tower's log-delivery statements are preserved; nothing is re-declared.
- **KMS decrypt**: an additive **`aws_kms_grant`** per reader account (grantee = account root), created in the key's account. A grant never reads or replaces the key policy, so the Control Tower key policy is left untouched — no snapshot needed. The reading account's own IAM narrows the actual use (S3 context).

## Changes

- `terraform-aws-s3-bucket-read`:
  - New `aws.kms` provider alias — the log bucket's KMS key can live in a different account than the bucket. Used by `aws_kms_grant.cxm_inplace`. Map both aliases to the same provider where they share an account.
  - New `manage_kms_grant` toggle; **removed** `manage_kms_key_policy`, `existing_kms_key_policy_json`, the `aws_kms_key_policy` resource and its snapshot-merge, and the `inplace_query_kms_key_policy_statement_json` output.
- Root `main.tf` / `variables.tf`: `cloudtrail_enable_inplace_query` (drives bucket-policy merge + KMS grant), `cloudtrail_inplace_query_object_prefix`; passes `aws.kms` to all three `terraform-aws-s3-bucket-read` instances (cloudtrail → `aws.root`).

## Notes

- Defaults off — existing callers unaffected.
- `aws.kms` is now required by `terraform-aws-s3-bucket-read`; the root module supplies it for all three instances.
- Apply-time prerequisite: `kms:CreateGrant` allowed on the management account for the CloudTrail key (no SCP block).
- The root README's provider-requirements table ordering is nondeterministic under terraform-docs with aliased providers (cosmetic).
